### PR TITLE
Fix https://github.com/Zuzu-Typ/PyGLM/issues/2

### DIFF
--- a/glm/detail/type_vec2.py
+++ b/glm/detail/type_vec2.py
@@ -14,7 +14,7 @@ class tvec2:
         if len(args) == 1:
             # from tvec2
             if type(args[0]) in dtypes:
-                self.arr = numpy.array(args[0], dtype=self.dtype)
+                self.arr = numpy.array([args[0]]*2, dtype=self.dtype)
                 
             elif pyglmCompareType(args[0], tvec2) or pyglmCompareType(args[0], tvec3) or pyglmCompareType(args[0], tvec4):
                 self.arr = args[0].arr[:2]
@@ -24,6 +24,9 @@ class tvec2:
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])
+
+            else:
+                raise TypeError("expected float or tvec2, got {}".format(type(args[0])))
 
         elif len(args) == 2:
             # check types

--- a/glm/detail/type_vec3.py
+++ b/glm/detail/type_vec3.py
@@ -14,7 +14,7 @@ class tvec3:
         if len(args) == 1:
             # from tvec
             if type(args[0]) in dtypes:
-                self.arr = numpy.array(args[0], dtype=self.dtype)
+                self.arr = numpy.array([args[0]]*3, dtype=self.dtype)
                 
             elif pyglmCompareType(args[0], tvec3) or pyglmCompareType(args[0], tvec4):
                 self.arr = args[0].arr[:3]
@@ -24,6 +24,9 @@ class tvec3:
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])
+
+            else:
+                raise TypeError("expected float or tvec3, got {}".format(type(args[0])))
 
         elif len(args) == 2:
             # check types


### PR DESCRIPTION
ctor of tvec2, tvec3 and tvec4 was not filing the underlining numpy array, this made tmat* unable to do a __mul__ (and probably other ops) between a matrix and a vector built this way.