### PR TITLE
Fix https://github.com/Zuzu-Typ/PyGLM/issues/2

### DIFF
--- a/glm/detail/type_mat2x2.py
+++ b/glm/detail/type_mat2x2.py
@@ -9,7 +9,9 @@ class tmat2x2:
         self.col_type = self.row_type = tvec2
 
         if len(args) == 1:
-            if pyglmTypeIn(args[0], (tmat2x2, tmat2x3, tmat2x4, tmat3x2, tmat3x3, tmat3x4, tmat4x2, tmat4x3, tmat4x4)):
+            if type(args[0]) == numpy.matrixlib.defmatrix.matrix and args[0].size == 4 and args[0].shape == (2,2):
+                self.value = args[0].copy()
+            elif pyglmTypeIn(args[0], (tmat2x2, tmat2x3, tmat2x4, tmat3x2, tmat3x3, tmat3x4, tmat4x2, tmat4x3, tmat4x4)):
                 self.value = args[0].value[:2,:2]
 
             elif pyglmCompareType(args[0], tvec4):
@@ -158,6 +160,9 @@ class tmat2x2:
                     return tmat3x2(value * self.value)
                 if value.shape == (4,2):
                     return tmat4x2(value * self.value)
+
+            if type(value) in dtypes:
+                return tmat2x2(self.value * value)
             
             return rmul(self)
             
@@ -217,6 +222,7 @@ class tmat2x2:
                 if value.shape == (4,2):
                     return tmat4x2(self.value * value)
             
+            return tmat2x2(self.value * value)
         except:
             raise TypeError("unsupported operand type(s) for *: 'tmat2x2' and '{}'".format(type(value)))
 ##        if type(value) in dtypes:

--- a/glm/detail/type_mat3x2.py
+++ b/glm/detail/type_mat3x2.py
@@ -23,9 +23,9 @@ class tmat3x2:
                               (0,0)]
                 
             elif type(args[0]) in dtypes:
-                self.value = [(args[0],0),
+                self.value =  numpy.matrix([(args[0],0),
                               (0,args[0]),
-                              (0,0)]
+                              (0,0)], dtype=self.dtype)
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])

--- a/glm/detail/type_mat3x3.py
+++ b/glm/detail/type_mat3x3.py
@@ -11,7 +11,7 @@ class tmat3x3:
         self.row_type = tvec3
 
         if len(args) == 1:
-            if type(args[0]) == numpy.matrixlib.defmatrix.matrix and args[0].size == 4 and args[0].shape == (2,2):
+            if type(args[0]) == numpy.matrixlib.defmatrix.matrix and args[0].size == 9 and args[0].shape == (3,3):
                 self.value = args[0].copy()
                 
             if pyglmTypeIn(args[0], (tmat3x3, tmat4x3, tmat3x4, tmat4x4)):
@@ -184,7 +184,9 @@ class tmat3x3:
                     return tmat3x3(value * self.value)
                 if value.shape == (4,3):
                     return tmat4x3(value * self.value)
-            
+            if type(value) in dtypes:
+                return tmat3x3(self.value * value)
+
             return rmul(self)
             
         except:

--- a/glm/detail/type_mat3x4.py
+++ b/glm/detail/type_mat3x4.py
@@ -43,9 +43,9 @@ class tmat3x4:
                               (0, 0, 1, 0)]
                 
             elif type(args[0]) in dtypes:
-                self.value = [(args[0],0, 0),
-                              (0,args[0], 0),
-                              (0,0, args[0])]
+                self.value = numpy.matrix([(args[0],0, 0, 0),
+                              (0,args[0], 0, 0),
+                              (0,0, args[0], 0)], dtype=self.dtype)
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])

--- a/glm/detail/type_mat4x4.py
+++ b/glm/detail/type_mat4x4.py
@@ -166,6 +166,9 @@ class tmat4x4:
                 if value.shape == (4,4):
                     return tmat4x4(value * self.value)
             
+            if type(value) in dtypes:
+                return tmat4x4(self.value * value)
+
             return rmul(self)
             
         except:

--- a/glm/detail/type_vec2.py
+++ b/glm/detail/type_vec2.py
@@ -14,7 +14,7 @@ class tvec2:
         if len(args) == 1:
             # from tvec2
             if type(args[0]) in dtypes:
-                self.arr = numpy.array(args[0], dtype=self.dtype)
+                self.arr = numpy.array([args[0]]*2, dtype=self.dtype)
                 
             elif pyglmCompareType(args[0], tvec2) or pyglmCompareType(args[0], tvec3) or pyglmCompareType(args[0], tvec4):
                 self.arr = args[0].arr[:2]
@@ -24,6 +24,9 @@ class tvec2:
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])
+
+            else:
+                raise TypeError("expected float or tvec2, got {}".format(type(args[0])))
 
         elif len(args) == 2:
             # check types

--- a/glm/detail/type_vec3.py
+++ b/glm/detail/type_vec3.py
@@ -94,12 +94,12 @@ class tvec3:
 
     def __ne__(self, value):
         if type(value) in dtypes:
-            return (self.arr[0] != value and self.arr[1] != value and self.arr[2] != value)
+            return (self.arr[0] != value or self.arr[1] != value or self.arr[2] != value)
         elif pyglmCompareType(value, tvec3):
-            return (self.arr[0] != value.x and self.arr[1] != value.y and self.arr[2] != value.z)
+            return (self.arr[0] != value.x or self.arr[1] != value.y or self.arr[2] != value.z)
         else:
             try:
-                return (self.arr[0] != value[0] and self.arr[1] != value[1] and self.arr[2] != value[2])
+                return (self.arr[0] != value[0] or self.arr[1] != value[1] or self.arr[2] != value[2])
             except:
                 raise TypeError("unsupported operand type(s) for !=: 'tvec3' and '{}'".format(type(value)))
 

--- a/glm/detail/type_vec3.py
+++ b/glm/detail/type_vec3.py
@@ -14,7 +14,7 @@ class tvec3:
         if len(args) == 1:
             # from tvec
             if type(args[0]) in dtypes:
-                self.arr = numpy.array(args[0], dtype=self.dtype)
+                self.arr = numpy.array([args[0]]*3, dtype=self.dtype)
                 
             elif pyglmCompareType(args[0], tvec3) or pyglmCompareType(args[0], tvec4):
                 self.arr = args[0].arr[:3]
@@ -24,6 +24,9 @@ class tvec3:
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])
+
+            else:
+                raise TypeError("expected float or tvec3, got {}".format(type(args[0])))
 
         elif len(args) == 2:
             # check types

--- a/glm/detail/type_vec4.py
+++ b/glm/detail/type_vec4.py
@@ -123,12 +123,12 @@ class tvec4:
 
     def __ne__(self, value):
         if type(value) in dtypes:
-            return (self.arr[0] != value and self.arr[1] != value and self.arr[2] != value and self.arr[3] != value)
+            return (self.arr[0] != value or self.arr[1] != value or self.arr[2] != value or self.arr[3] != value)
         elif pyglmCompareType(value, tvec4):
-            return (self.arr[0] != value.x and self.arr[1] != value.y and self.arr[2] != value.z and self.arr[3] != value.w)
+            return (self.arr[0] != value.x or self.arr[1] != value.y or self.arr[2] != value.z or self.arr[3] != value.w)
         else:
             try:
-                return (self.arr[0] != value[0] and self.arr[1] != value[1] and self.arr[2] != value[2] and self.arr[3] != value[2])
+                return (self.arr[0] != value[0] or self.arr[1] != value[1] or self.arr[2] != value[2] or self.arr[3] != value[2])
             except:
                 raise TypeError("unsupported operand type(s) for !=: 'tvec4' and '{}'".format(type(value)))
 

--- a/glm/detail/type_vec4.py
+++ b/glm/detail/type_vec4.py
@@ -14,7 +14,7 @@ class tvec4:
         if len(args) == 1:
             # from tvec
             if type(args[0]) in dtypes:
-                self.arr = numpy.array(args[0], dtype=self.dtype)
+                self.arr = numpy.array([args[0]]*4, dtype=self.dtype)
                 
             elif pyglmCompareType(args[0], tvec4):
                 self.arr = args[0].arr.copy()
@@ -25,6 +25,9 @@ class tvec4:
 
             elif type(args[0]) in ltypes:
                 self.__init__(*args[0])
+
+            else:
+                raise TypeError("expected float or tvec4, got {}".format(type(args[0])))
 
         elif len(args) == 2:
             # check types
@@ -76,7 +79,7 @@ class tvec4:
             if not type(args[2]) in dtypes:
                 raise TypeError("expected int or float values, got {}".format(type(args[2])))
             if not type(args[3]) in dtypes:
-                raise TypeError("expected int or float values, got {}".format(type(args[2])))
+                raise TypeError("expected int or float values, got {}".format(type(args[3])))
             self.arr = numpy.array(args,dtype=self.dtype)
 
         elif len(args) > 4:


### PR DESCRIPTION
ctor of tvec2, tvec3 and tvec4 was not filing the underlining numpy array, this made mat*vec raise an exception when the rhs is built ala vec4(4.0)