### PR TITLE
add Py_TPFLAGS_CHECKTYPES to PyTypeObject, it's required for py2.7

### DIFF
--- a/glminternalfuncs.h
+++ b/glminternalfuncs.h
@@ -4575,103 +4575,184 @@ static PyObject * pack_tvec4(double x, double y, double z, double w) {
 }
 
 static PyObject * pack_tmat2x2(double x0, double x1, double y0, double y1) {
-	PyObject* argList = Py_BuildValue("OO", pack_tvec2(x0,x1), pack_tvec2(y0,y1));
+	PyObject* v0, *v1;
+
+	v0 = pack_tvec2(x0, x1);
+	v1 = pack_tvec2(y0, y1);
+
+	PyObject* argList = Py_BuildValue("OO", v0, v1);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat2x2Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
 
 	return obj_out;
 }
 static PyObject * pack_tmat2x3(double x0, double x1, double x2, double y0, double y1, double y2) {
-	PyObject* argList = Py_BuildValue("OO", pack_tvec3(x0, x1, x2), pack_tvec3(y0, y1, y2));
+	PyObject* v0, *v1;
+
+	v0 = pack_tvec3(x0, x1, x2);
+	v1 = pack_tvec3(y0, y1, y2);
+
+	PyObject* argList = Py_BuildValue("OO", v0, v1);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat2x3Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
 
 	return obj_out;
 }
 static PyObject * pack_tmat2x4(double x0, double x1, double x2, double x3, double y0, double y1, double y2, double y3) {
-	PyObject* argList = Py_BuildValue("OO", pack_tvec4(x0, x1, x2, x3), pack_tvec4(y0, y1, y2, y3));
+	PyObject* v0, *v1;
+
+	v0 = pack_tvec4(x0, x1, x2, x3);
+	v1 = pack_tvec4(y0, y1, y2, y3);
+
+	PyObject* argList = Py_BuildValue("OO", v0, v1);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat2x4Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
 
 	return obj_out;
 }
 
 static PyObject * pack_tmat3x2(double x0, double x1, double y0, double y1, double z0, double z1) {
-	PyObject* argList = Py_BuildValue("OOO", pack_tvec2(x0, x1), pack_tvec2(y0, y1), pack_tvec2(z0, z1));
+	PyObject* v0, *v1, *v2;
+
+	v0 = pack_tvec2(x0, x1);
+	v1 = pack_tvec2(y0, y1);
+	v2 = pack_tvec2(z0, z1);
+
+	PyObject* argList = Py_BuildValue("OOO", v0, v1, v2);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat3x2Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
+	Py_DECREF(v2);
 
 	return obj_out;
 }
 static PyObject * pack_tmat3x3(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2) {
-	PyObject* argList = Py_BuildValue("OOO", pack_tvec3(x0, x1, x2), pack_tvec3(y0, y1, y2), pack_tvec3(z0, z1, z2));
+	PyObject* v0, *v1, *v2;
+
+	v0 = pack_tvec3(x0, x1, x2);
+	v1 = pack_tvec3(y0, y1, y2);
+	v2 = pack_tvec3(z0, z1, z2);
+
+	PyObject* argList = Py_BuildValue("OOO", v0, v1, v2);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat3x3Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
+	Py_DECREF(v2);
 
 	return obj_out;
 }
 static PyObject * pack_tmat3x4(double x0, double x1, double x2, double x3, double y0, double y1, double y2, double y3, double z0, double z1, double z2, double z3) {
-	PyObject* argList = Py_BuildValue("OOO", pack_tvec4(x0, x1, x2, x3), pack_tvec4(y0, y1, y2, y3), pack_tvec4(z0, z1, z2, z3));
+	PyObject* v0, *v1, *v2;
+
+	v0 = pack_tvec4(x0, x1, x2, x3);
+	v1 = pack_tvec4(y0, y1, y2, y3);
+	v2 = pack_tvec4(z0, z1, z2, z3);
+
+	PyObject* argList = Py_BuildValue("OOO", v0, v1, v2);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat3x4Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
+	Py_DECREF(v2);
 
 	return obj_out;
 }
 
 static PyObject * pack_tmat4x2(double x0, double x1, double y0, double y1, double z0, double z1, double w0, double w1) {
-	PyObject* argList = Py_BuildValue("OOOO", pack_tvec2(x0, x1), pack_tvec2(y0, y1), pack_tvec2(z0, z1), pack_tvec2(w0, w1));
+	PyObject* v0, *v1, *v2, *v3;
+
+	v0 = pack_tvec2(x0, x1);
+	v1 = pack_tvec2(y0, y1);
+	v2 = pack_tvec2(z0, z1);
+	v3 = pack_tvec2(w0, w1);
+
+	PyObject* argList = Py_BuildValue("OOOO", v0, v1, v2, v3);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat4x2Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
+	Py_DECREF(v2);
+	Py_DECREF(v3);
 
 	return obj_out;
 }
 static PyObject * pack_tmat4x3(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, double w0, double w1, double w2) {
-	PyObject* argList = Py_BuildValue("OOOO", pack_tvec3(x0, x1, x2), pack_tvec3(y0, y1, y2), pack_tvec3(z0, z1, z2), pack_tvec3(w0, w1, w2));
+	PyObject* v0, *v1, *v2, *v3;
+
+	v0 = pack_tvec3(x0, x1, x2);
+	v1 = pack_tvec3(y0, y1, y2);
+	v2 = pack_tvec3(z0, z1, z2);
+	v3 = pack_tvec3(w0, w1, w2);
+
+	PyObject* argList = Py_BuildValue("OOOO", v0, v1, v2, v3);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat4x3Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
+	Py_DECREF(v2);
+	Py_DECREF(v3);
 
 	return obj_out;
 }
 static PyObject * pack_tmat4x4(double x0, double x1, double x2, double x3, double y0, double y1, double y2, double y3, double z0, double z1, double z2, double z3, double w0, double w1, double w2, double w3) {
-	PyObject* argList = Py_BuildValue("OOOO", pack_tvec4(x0, x1, x2, x3), pack_tvec4(y0, y1, y2, y3), pack_tvec4(z0, z1, z2, z3), pack_tvec4(w0, w1, w2, w3));
+	PyObject* v0, *v1, *v2, *v3;
+
+	v0 = pack_tvec4(x0, x1, x2, x3);
+	v1 = pack_tvec4(y0, y1, y2, y3);
+	v2 = pack_tvec4(z0, z1, z2, z3);
+	v3 = pack_tvec4(w0, w1, w2, w3);
+
+	PyObject* argList = Py_BuildValue("OOOO", v0, v1, v2, v3);
 
 	/* Call the class object. */
 	PyObject *obj_out = PyObject_CallObject((PyObject *)&tmat4x4Type, argList);
 
 	/* Release the argument list. */
 	Py_DECREF(argList);
+	Py_DECREF(v0);
+	Py_DECREF(v1);
+	Py_DECREF(v2);
+	Py_DECREF(v3);
 
 	return obj_out;
 }

--- a/pyglm.c
+++ b/pyglm.c
@@ -5,6 +5,10 @@
 
 #define PY3K (PY_VERSION_HEX >= 0x03000000)
 
+#if PY3K
+#define Py_TPFLAGS_CHECKTYPES 0
+#endif
+
 PyObject* c_void_p = NULL;
 
 #include "glmtypes.h"

--- a/type_mat2x2.h
+++ b/type_mat2x2.h
@@ -934,7 +934,8 @@ static PyTypeObject tmat2x2Type = {
 	(setattrofunc)tmat2x2_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat2x2( <tmat2x2 compatible type(s)> )\n2 columns of 2 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat2x3.h
+++ b/type_mat2x3.h
@@ -953,7 +953,8 @@ static PyTypeObject tmat2x3Type = {
 	(setattrofunc)tmat2x3_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat2x3( <tmat2x3 compatible type(s)> )\n2 columns of 3 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat2x4.h
+++ b/type_mat2x4.h
@@ -1016,7 +1016,8 @@ static PyTypeObject tmat2x4Type = {
 	(setattrofunc)tmat2x4_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat2x4( <tmat2x4 compatible type(s)> )\n2 columns of 4 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat3x2.h
+++ b/type_mat3x2.h
@@ -989,7 +989,8 @@ static PyTypeObject tmat3x2Type = {
 	(setattrofunc)tmat3x2_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat3x2( <tmat3x2 compatible type(s)> )\n3 columns of 2 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat3x3.h
+++ b/type_mat3x3.h
@@ -1130,7 +1130,8 @@ static PyTypeObject tmat3x3Type = {
 	(setattrofunc)tmat3x3_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat3x3( <tmat3x3 compatible type(s)> )\n3 columns of 3 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat3x4.h
+++ b/type_mat3x4.h
@@ -1171,7 +1171,8 @@ static PyTypeObject tmat3x4Type = {
 	(setattrofunc)tmat3x4_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat3x4( <tmat3x4 compatible type(s)> )\n3 columns of 3 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat4x2.h
+++ b/type_mat4x2.h
@@ -1085,7 +1085,8 @@ static PyTypeObject tmat4x2Type = {
 	(setattrofunc)tmat4x2_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat4x2( <tmat4x2 compatible type(s)> )\n4 columns of 2 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat4x3.h
+++ b/type_mat4x3.h
@@ -1203,7 +1203,8 @@ static PyTypeObject tmat4x3Type = {
 	(setattrofunc)tmat4x3_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat4x3( <tmat4x3 compatible type(s)> )\n4 columns of 3 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_mat4x4.h
+++ b/type_mat4x4.h
@@ -1360,7 +1360,8 @@ static PyTypeObject tmat4x4Type = {
 	(setattrofunc)tmat4x4_setattr,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tmat4x4( <tmat4x4 compatible type(s)> )\n4 columns of 4 components matrix of medium qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_vec2.h
+++ b/type_vec2.h
@@ -1014,7 +1014,8 @@ static PyTypeObject tvec2Type = {
 	0,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tvec2( <tvec2 compatible type(s)> )\n2 components vector of medium double-qualifier floating-point numbers.",           /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_vec3.h
+++ b/type_vec3.h
@@ -1130,7 +1130,8 @@ static PyTypeObject tvec3Type = {
 	0,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tvec3( <tvec3 compatible type(s)> )\n3 components vector of medium double-qualifier floating-point numbers.",            /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */

--- a/type_vec4.h
+++ b/type_vec4.h
@@ -1232,7 +1232,8 @@ static PyTypeObject tvec4Type = {
 	0,                         /* tp_setattro */
 	0,                         /* tp_as_buffer */
 	Py_TPFLAGS_DEFAULT |
-	Py_TPFLAGS_BASETYPE,   /* tp_flags */
+	Py_TPFLAGS_BASETYPE |
+	Py_TPFLAGS_CHECKTYPES,   /* tp_flags */
 	"tvec4( <tvec4 compatible type(s)> )\n4 components vector of medium double-qualifier floating-point numbers.",            /* tp_doc */
 	0,                         /* tp_traverse */
 	0,                         /* tp_clear */


### PR DESCRIPTION
without this flag binary ops with different type raise a TypeError when operand types are different, this fix issue #10 