### PR TITLE
Typo fixes for item assignment in vec4 and mvec4.

### DIFF
--- a/PyGLM.cpp
+++ b/PyGLM.cpp
@@ -16666,7 +16666,7 @@ static int vec4_sq_ass_item(vec<4, T> * self, Py_ssize_t index, PyObject * value
 		self->super_type.z = f;
 		return 0;
 	case 3:
-		self->super_type.z = f;
+		self->super_type.w = f;
 		return 0;
 	default:
 		PyErr_SetString(PyExc_IndexError, "index out of range");
@@ -17599,7 +17599,7 @@ static int mvec4_sq_ass_item(mvec<4, T> * self, Py_ssize_t index, PyObject * val
 		self->super_type->z = f;
 		return 0;
 	case 3:
-		self->super_type->z = f;
+		self->super_type->w = f;
 		return 0;
 	default:
 		PyErr_SetString(PyExc_IndexError, "index out of range");


### PR DESCRIPTION
For example, on the master branch:

```python
import glm

x = glm.vec4()
x[3] = 1
print(x)
# vec4(            0,            0,            1,            0 )

y = glm.mat4(0)
y2 = y[0]
y2[3] = 1
print(y2)
# mvec4(            0,            0,            1,            0 )
```