### PR TITLE
Replaced uses of 'UNBRACKET' by typedefs to fix compiling on clang

### DIFF
--- a/PyGLM/types/vec/bool/vec1.h
+++ b/PyGLM/types/vec/bool/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, bool> vec1_bool_t;
+
 static PyMemberDef hbvec1_members[] = {
-	{ (char*)"x", T_BOOL, offsetof(UNBRACKET(vec<1, bool>), super_type.x), 0, (char*)"bvec1.x" },
+	{ (char*)"x", T_BOOL, offsetof(vec1_bool_t, super_type.x), 0, (char*)"bvec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hbvec1_methods[] = {

--- a/PyGLM/types/vec/bool/vec2.h
+++ b/PyGLM/types/vec/bool/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, bool> vec2_bool_t;
+
 static PyMemberDef hbvec2_members[] = {
-	{ (char*)"x", T_BOOL, offsetof(UNBRACKET(vec<2, bool>), super_type.x), 0, (char*)"bvec2.x" },
-	{ (char*)"y", T_BOOL, offsetof(UNBRACKET(vec<2, bool>), super_type.y), 0, (char*)"bvec2.y" },
+	{ (char*)"x", T_BOOL, offsetof(vec2_bool_t, super_type.x), 0, (char*)"bvec2.x" },
+	{ (char*)"y", T_BOOL, offsetof(vec2_bool_t, super_type.y), 0, (char*)"bvec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hbvec2_methods[] = {

--- a/PyGLM/types/vec/bool/vec3.h
+++ b/PyGLM/types/vec/bool/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, bool> vec3_bool_t;
+
 static PyMemberDef hbvec3_members[] = {
-	{ (char*)"x", T_BOOL, offsetof(UNBRACKET(vec<3, bool>), super_type.x), 0, (char*)"bvec3.x" },
-	{ (char*)"y", T_BOOL, offsetof(UNBRACKET(vec<3, bool>), super_type.y), 0, (char*)"bvec3.y" },
-	{ (char*)"z", T_BOOL, offsetof(UNBRACKET(vec<3, bool>), super_type.z), 0, (char*)"bvec3.z" },
+	{ (char*)"x", T_BOOL, offsetof(vec3_bool_t, super_type.x), 0, (char*)"bvec3.x" },
+	{ (char*)"y", T_BOOL, offsetof(vec3_bool_t, super_type.y), 0, (char*)"bvec3.y" },
+	{ (char*)"z", T_BOOL, offsetof(vec3_bool_t, super_type.z), 0, (char*)"bvec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hbvec3_methods[] = {

--- a/PyGLM/types/vec/bool/vec4.h
+++ b/PyGLM/types/vec/bool/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, bool> vec4_bool_t;
+
 static PyMemberDef hbvec4_members[] = {
-	{ (char*)"x", T_BOOL, offsetof(UNBRACKET(vec<4, bool>), super_type.x), 0, (char*)"bvec4.x" },
-	{ (char*)"y", T_BOOL, offsetof(UNBRACKET(vec<4, bool>), super_type.y), 0, (char*)"bvec4.y" },
-	{ (char*)"z", T_BOOL, offsetof(UNBRACKET(vec<4, bool>), super_type.z), 0, (char*)"bvec4.z" },
-	{ (char*)"w", T_BOOL, offsetof(UNBRACKET(vec<4, bool>), super_type.w), 0, (char*)"bvec4.w" },
+	{ (char*)"x", T_BOOL, offsetof(vec4_bool_t, super_type.x), 0, (char*)"bvec4.x" },
+	{ (char*)"y", T_BOOL, offsetof(vec4_bool_t, super_type.y), 0, (char*)"bvec4.y" },
+	{ (char*)"z", T_BOOL, offsetof(vec4_bool_t, super_type.z), 0, (char*)"bvec4.z" },
+	{ (char*)"w", T_BOOL, offsetof(vec4_bool_t, super_type.w), 0, (char*)"bvec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hbvec4_methods[] = {

--- a/PyGLM/types/vec/double/vec1.h
+++ b/PyGLM/types/vec/double/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, double> vec1_double_t;
+
 static PyMemberDef hdvec1_members[] = {
-	{ (char*)"x", T_DOUBLE, offsetof(UNBRACKET(vec<1, double>), super_type.x), 0, (char*)"dvec1.x" },
+	{ (char*)"x", T_DOUBLE, offsetof(vec1_double_t, super_type.x), 0, (char*)"dvec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hdvec1_methods[] = {

--- a/PyGLM/types/vec/double/vec2.h
+++ b/PyGLM/types/vec/double/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, double> vec2_double_t;
+
 static PyMemberDef hdvec2_members[] = {
-	{ (char*)"x", T_DOUBLE, offsetof(UNBRACKET(vec<2, double>), super_type.x), 0, (char*)"dvec2.x" },
-	{ (char*)"y", T_DOUBLE, offsetof(UNBRACKET(vec<2, double>), super_type.y), 0, (char*)"dvec2.y" },
+	{ (char*)"x", T_DOUBLE, offsetof(vec2_double_t, super_type.x), 0, (char*)"dvec2.x" },
+	{ (char*)"y", T_DOUBLE, offsetof(vec2_double_t, super_type.y), 0, (char*)"dvec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hdvec2_methods[] = {

--- a/PyGLM/types/vec/double/vec3.h
+++ b/PyGLM/types/vec/double/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, double> vec3_double_t;
+
 static PyMemberDef hdvec3_members[] = {
-	{ (char*)"x", T_DOUBLE, offsetof(UNBRACKET(vec<3, double>), super_type.x), 0, (char*)"dvec3.x" },
-	{ (char*)"y", T_DOUBLE, offsetof(UNBRACKET(vec<3, double>), super_type.y), 0, (char*)"dvec3.y" },
-	{ (char*)"z", T_DOUBLE, offsetof(UNBRACKET(vec<3, double>), super_type.z), 0, (char*)"dvec3.z" },
+	{ (char*)"x", T_DOUBLE, offsetof(vec3_double_t, super_type.x), 0, (char*)"dvec3.x" },
+	{ (char*)"y", T_DOUBLE, offsetof(vec3_double_t, super_type.y), 0, (char*)"dvec3.y" },
+	{ (char*)"z", T_DOUBLE, offsetof(vec3_double_t, super_type.z), 0, (char*)"dvec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hdvec3_methods[] = {

--- a/PyGLM/types/vec/double/vec4.h
+++ b/PyGLM/types/vec/double/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, double> vec4_double_t;
+
 static PyMemberDef hdvec4_members[] = {
-	{ (char*)"x", T_DOUBLE, offsetof(UNBRACKET(vec<4, double>), super_type.x), 0, (char*)"dvec4.x" },
-	{ (char*)"y", T_DOUBLE, offsetof(UNBRACKET(vec<4, double>), super_type.y), 0, (char*)"dvec4.y" },
-	{ (char*)"z", T_DOUBLE, offsetof(UNBRACKET(vec<4, double>), super_type.z), 0, (char*)"dvec4.z" },
-	{ (char*)"w", T_DOUBLE, offsetof(UNBRACKET(vec<4, double>), super_type.w), 0, (char*)"dvec4.w" },
+	{ (char*)"x", T_DOUBLE, offsetof(vec4_double_t, super_type.x), 0, (char*)"dvec4.x" },
+	{ (char*)"y", T_DOUBLE, offsetof(vec4_double_t, super_type.y), 0, (char*)"dvec4.y" },
+	{ (char*)"z", T_DOUBLE, offsetof(vec4_double_t, super_type.z), 0, (char*)"dvec4.z" },
+	{ (char*)"w", T_DOUBLE, offsetof(vec4_double_t, super_type.w), 0, (char*)"dvec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hdvec4_methods[] = {

--- a/PyGLM/types/vec/float/vec1.h
+++ b/PyGLM/types/vec/float/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, float> vec1_float_t;
+
 static PyMemberDef hfvec1_members[] = {
-	{ (char*)"x", T_FLOAT, offsetof(UNBRACKET(vec<1, float>), super_type.x), 0, (char*)"vec1.x" },
+	{ (char*)"x", T_FLOAT, offsetof(vec1_float_t, super_type.x), 0, (char*)"vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hfvec1_methods[] = {

--- a/PyGLM/types/vec/float/vec2.h
+++ b/PyGLM/types/vec/float/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, float> vec2_float_t;
+
 static PyMemberDef hfvec2_members[] = {
-	{ (char*)"x", T_FLOAT, offsetof(UNBRACKET(vec<2, float>), super_type.x), 0, (char*)"vec2.x" },
-	{ (char*)"y", T_FLOAT, offsetof(UNBRACKET(vec<2, float>), super_type.y), 0, (char*)"vec2.y" },
+	{ (char*)"x", T_FLOAT, offsetof(vec2_float_t, super_type.x), 0, (char*)"vec2.x" },
+	{ (char*)"y", T_FLOAT, offsetof(vec2_float_t, super_type.y), 0, (char*)"vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hfvec2_methods[] = {

--- a/PyGLM/types/vec/float/vec3.h
+++ b/PyGLM/types/vec/float/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, float> vec3_float_t;
+
 static PyMemberDef hfvec3_members[] = {
-	{ (char*)"x", T_FLOAT, offsetof(UNBRACKET(vec<3, float>), super_type.x), 0, (char*)"vec3.x" },
-	{ (char*)"y", T_FLOAT, offsetof(UNBRACKET(vec<3, float>), super_type.y), 0, (char*)"vec3.y" },
-	{ (char*)"z", T_FLOAT, offsetof(UNBRACKET(vec<3, float>), super_type.z), 0, (char*)"vec3.z" },
+	{ (char*)"x", T_FLOAT, offsetof(vec3_float_t, super_type.x), 0, (char*)"vec3.x" },
+	{ (char*)"y", T_FLOAT, offsetof(vec3_float_t, super_type.y), 0, (char*)"vec3.y" },
+	{ (char*)"z", T_FLOAT, offsetof(vec3_float_t, super_type.z), 0, (char*)"vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hfvec3_methods[] = {

--- a/PyGLM/types/vec/float/vec4.h
+++ b/PyGLM/types/vec/float/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, float> vec4_float_t;
+
 static PyMemberDef hfvec4_members[] = {
-	{ (char*)"x", T_FLOAT, offsetof(UNBRACKET(vec<4, float>), super_type.x), 0, (char*)"vec4.x" },
-	{ (char*)"y", T_FLOAT, offsetof(UNBRACKET(vec<4, float>), super_type.y), 0, (char*)"vec4.y" },
-	{ (char*)"z", T_FLOAT, offsetof(UNBRACKET(vec<4, float>), super_type.z), 0, (char*)"vec4.z" },
-	{ (char*)"w", T_FLOAT, offsetof(UNBRACKET(vec<4, float>), super_type.w), 0, (char*)"vec4.w" },
+	{ (char*)"x", T_FLOAT, offsetof(vec4_float_t, super_type.x), 0, (char*)"vec4.x" },
+	{ (char*)"y", T_FLOAT, offsetof(vec4_float_t, super_type.y), 0, (char*)"vec4.y" },
+	{ (char*)"z", T_FLOAT, offsetof(vec4_float_t, super_type.z), 0, (char*)"vec4.z" },
+	{ (char*)"w", T_FLOAT, offsetof(vec4_float_t, super_type.w), 0, (char*)"vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hfvec4_methods[] = {

--- a/PyGLM/types/vec/int16/vec1.h
+++ b/PyGLM/types/vec/int16/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::i16> vec1_int16_t;
+
 static PyMemberDef hi16vec1_members[] = {
-	{ (char*)"x", T_SHORT, offsetof(UNBRACKET(vec<1, glm::i16>), super_type.x), 0, (char*)"i16vec1.x" },
+	{ (char*)"x", T_SHORT, offsetof(vec1_int16_t, super_type.x), 0, (char*)"i16vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi16vec1_methods[] = {

--- a/PyGLM/types/vec/int16/vec2.h
+++ b/PyGLM/types/vec/int16/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::i16> vec2_int16_t;
+
 static PyMemberDef hi16vec2_members[] = {
-	{ (char*)"x", T_SHORT, offsetof(UNBRACKET(vec<2, glm::i16>), super_type.x), 0, (char*)"i16vec2.x" },
-	{ (char*)"y", T_SHORT, offsetof(UNBRACKET(vec<2, glm::i16>), super_type.y), 0, (char*)"i16vec2.y" },
+	{ (char*)"x", T_SHORT, offsetof(vec2_int16_t, super_type.x), 0, (char*)"i16vec2.x" },
+	{ (char*)"y", T_SHORT, offsetof(vec2_int16_t, super_type.y), 0, (char*)"i16vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi16vec2_methods[] = {

--- a/PyGLM/types/vec/int16/vec3.h
+++ b/PyGLM/types/vec/int16/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::i16> vec3_int16_t;
+
 static PyMemberDef hi16vec3_members[] = {
-	{ (char*)"x", T_SHORT, offsetof(UNBRACKET(vec<3, glm::i16>), super_type.x), 0, (char*)"i16vec3.x" },
-	{ (char*)"y", T_SHORT, offsetof(UNBRACKET(vec<3, glm::i16>), super_type.y), 0, (char*)"i16vec3.y" },
-	{ (char*)"z", T_SHORT, offsetof(UNBRACKET(vec<3, glm::i16>), super_type.z), 0, (char*)"i16vec3.z" },
+	{ (char*)"x", T_SHORT, offsetof(vec3_int16_t, super_type.x), 0, (char*)"i16vec3.x" },
+	{ (char*)"y", T_SHORT, offsetof(vec3_int16_t, super_type.y), 0, (char*)"i16vec3.y" },
+	{ (char*)"z", T_SHORT, offsetof(vec3_int16_t, super_type.z), 0, (char*)"i16vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi16vec3_methods[] = {

--- a/PyGLM/types/vec/int16/vec4.h
+++ b/PyGLM/types/vec/int16/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::i16> vec4_int16_t;
+
 static PyMemberDef hi16vec4_members[] = {
-	{ (char*)"x", T_SHORT, offsetof(UNBRACKET(vec<4, glm::i16>), super_type.x), 0, (char*)"i16vec4.x" },
-	{ (char*)"y", T_SHORT, offsetof(UNBRACKET(vec<4, glm::i16>), super_type.y), 0, (char*)"i16vec4.y" },
-	{ (char*)"z", T_SHORT, offsetof(UNBRACKET(vec<4, glm::i16>), super_type.z), 0, (char*)"i16vec4.z" },
-	{ (char*)"w", T_SHORT, offsetof(UNBRACKET(vec<4, glm::i16>), super_type.w), 0, (char*)"i16vec4.w" },
+	{ (char*)"x", T_SHORT, offsetof(vec4_int16_t, super_type.x), 0, (char*)"i16vec4.x" },
+	{ (char*)"y", T_SHORT, offsetof(vec4_int16_t, super_type.y), 0, (char*)"i16vec4.y" },
+	{ (char*)"z", T_SHORT, offsetof(vec4_int16_t, super_type.z), 0, (char*)"i16vec4.z" },
+	{ (char*)"w", T_SHORT, offsetof(vec4_int16_t, super_type.w), 0, (char*)"i16vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi16vec4_methods[] = {

--- a/PyGLM/types/vec/int32/vec1.h
+++ b/PyGLM/types/vec/int32/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::i32> vec1_int32_t;
+
 static PyMemberDef hivec1_members[] = {
-	{ (char*)"x", T_INT, offsetof(UNBRACKET(vec<1, glm::i32>), super_type.x), 0, (char*)"ivec1.x" },
+	{ (char*)"x", T_INT, offsetof(vec1_int32_t, super_type.x), 0, (char*)"ivec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hivec1_methods[] = {

--- a/PyGLM/types/vec/int32/vec2.h
+++ b/PyGLM/types/vec/int32/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::i32> vec2_int32_t;
+
 static PyMemberDef hivec2_members[] = {
-	{ (char*)"x", T_INT, offsetof(UNBRACKET(vec<2, glm::i32>), super_type.x), 0, (char*)"ivec2.x" },
-	{ (char*)"y", T_INT, offsetof(UNBRACKET(vec<2, glm::i32>), super_type.y), 0, (char*)"ivec2.y" },
+	{ (char*)"x", T_INT, offsetof(vec2_int32_t, super_type.x), 0, (char*)"ivec2.x" },
+	{ (char*)"y", T_INT, offsetof(vec2_int32_t, super_type.y), 0, (char*)"ivec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hivec2_methods[] = {

--- a/PyGLM/types/vec/int32/vec3.h
+++ b/PyGLM/types/vec/int32/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::i32> vec3_int32_t;
+
 static PyMemberDef hivec3_members[] = {
-	{ (char*)"x", T_INT, offsetof(UNBRACKET(vec<3, glm::i32>), super_type.x), 0, (char*)"ivec3.x" },
-	{ (char*)"y", T_INT, offsetof(UNBRACKET(vec<3, glm::i32>), super_type.y), 0, (char*)"ivec3.y" },
-	{ (char*)"z", T_INT, offsetof(UNBRACKET(vec<3, glm::i32>), super_type.z), 0, (char*)"ivec3.z" },
+	{ (char*)"x", T_INT, offsetof(vec3_int32_t, super_type.x), 0, (char*)"ivec3.x" },
+	{ (char*)"y", T_INT, offsetof(vec3_int32_t, super_type.y), 0, (char*)"ivec3.y" },
+	{ (char*)"z", T_INT, offsetof(vec3_int32_t, super_type.z), 0, (char*)"ivec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hivec3_methods[] = {

--- a/PyGLM/types/vec/int32/vec4.h
+++ b/PyGLM/types/vec/int32/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::i32> vec4_int32_t;
+
 static PyMemberDef hivec4_members[] = {
-	{ (char*)"x", T_INT, offsetof(UNBRACKET(vec<4, glm::i32>), super_type.x), 0, (char*)"ivec4.x" },
-	{ (char*)"y", T_INT, offsetof(UNBRACKET(vec<4, glm::i32>), super_type.y), 0, (char*)"ivec4.y" },
-	{ (char*)"z", T_INT, offsetof(UNBRACKET(vec<4, glm::i32>), super_type.z), 0, (char*)"ivec4.z" },
-	{ (char*)"w", T_INT, offsetof(UNBRACKET(vec<4, glm::i32>), super_type.w), 0, (char*)"ivec4.w" },
+	{ (char*)"x", T_INT, offsetof(vec4_int32_t, super_type.x), 0, (char*)"ivec4.x" },
+	{ (char*)"y", T_INT, offsetof(vec4_int32_t, super_type.y), 0, (char*)"ivec4.y" },
+	{ (char*)"z", T_INT, offsetof(vec4_int32_t, super_type.z), 0, (char*)"ivec4.z" },
+	{ (char*)"w", T_INT, offsetof(vec4_int32_t, super_type.w), 0, (char*)"ivec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hivec4_methods[] = {

--- a/PyGLM/types/vec/int64/vec1.h
+++ b/PyGLM/types/vec/int64/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::i64> vec1_int64_t;
+
 static PyMemberDef hi64vec1_members[] = {
-	{ (char*)"x", T_LONGLONG, offsetof(UNBRACKET(vec<1, glm::i64>), super_type.x), 0, (char*)"i64vec1.x" },
+	{ (char*)"x", T_LONGLONG, offsetof(vec1_int64_t, super_type.x), 0, (char*)"i64vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi64vec1_methods[] = {

--- a/PyGLM/types/vec/int64/vec2.h
+++ b/PyGLM/types/vec/int64/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::i64> vec2_int64_t;
+
 static PyMemberDef hi64vec2_members[] = {
-	{ (char*)"x", T_LONGLONG, offsetof(UNBRACKET(vec<2, glm::i64>), super_type.x), 0, (char*)"i64vec2.x" },
-	{ (char*)"y", T_LONGLONG, offsetof(UNBRACKET(vec<2, glm::i64>), super_type.y), 0, (char*)"i64vec2.y" },
+	{ (char*)"x", T_LONGLONG, offsetof(vec2_int64_t, super_type.x), 0, (char*)"i64vec2.x" },
+	{ (char*)"y", T_LONGLONG, offsetof(vec2_int64_t, super_type.y), 0, (char*)"i64vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi64vec2_methods[] = {

--- a/PyGLM/types/vec/int64/vec3.h
+++ b/PyGLM/types/vec/int64/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::i64> vec3_int64_t;
+
 static PyMemberDef hi64vec3_members[] = {
-	{ (char*)"x", T_LONGLONG, offsetof(UNBRACKET(vec<3, glm::i64>), super_type.x), 0, (char*)"i64vec3.x" },
-	{ (char*)"y", T_LONGLONG, offsetof(UNBRACKET(vec<3, glm::i64>), super_type.y), 0, (char*)"i64vec3.y" },
-	{ (char*)"z", T_LONGLONG, offsetof(UNBRACKET(vec<3, glm::i64>), super_type.z), 0, (char*)"i64vec3.z" },
+	{ (char*)"x", T_LONGLONG, offsetof(vec3_int64_t, super_type.x), 0, (char*)"i64vec3.x" },
+	{ (char*)"y", T_LONGLONG, offsetof(vec3_int64_t, super_type.y), 0, (char*)"i64vec3.y" },
+	{ (char*)"z", T_LONGLONG, offsetof(vec3_int64_t, super_type.z), 0, (char*)"i64vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi64vec3_methods[] = {

--- a/PyGLM/types/vec/int64/vec4.h
+++ b/PyGLM/types/vec/int64/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::i64> vec4_int64_t;
+
 static PyMemberDef hi64vec4_members[] = {
-	{ (char*)"x", T_LONGLONG, offsetof(UNBRACKET(vec<4, glm::i64>), super_type.x), 0, (char*)"i64vec4.x" },
-	{ (char*)"y", T_LONGLONG, offsetof(UNBRACKET(vec<4, glm::i64>), super_type.y), 0, (char*)"i64vec4.y" },
-	{ (char*)"z", T_LONGLONG, offsetof(UNBRACKET(vec<4, glm::i64>), super_type.z), 0, (char*)"i64vec4.z" },
-	{ (char*)"w", T_LONGLONG, offsetof(UNBRACKET(vec<4, glm::i64>), super_type.w), 0, (char*)"i64vec4.w" },
+	{ (char*)"x", T_LONGLONG, offsetof(vec4_int64_t, super_type.x), 0, (char*)"i64vec4.x" },
+	{ (char*)"y", T_LONGLONG, offsetof(vec4_int64_t, super_type.y), 0, (char*)"i64vec4.y" },
+	{ (char*)"z", T_LONGLONG, offsetof(vec4_int64_t, super_type.z), 0, (char*)"i64vec4.z" },
+	{ (char*)"w", T_LONGLONG, offsetof(vec4_int64_t, super_type.w), 0, (char*)"i64vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi64vec4_methods[] = {

--- a/PyGLM/types/vec/int8/vec1.h
+++ b/PyGLM/types/vec/int8/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::i8> vec1_int8_t;
+
 static PyMemberDef hi8vec1_members[] = {
-	{ (char*)"x", T_BYTE, offsetof(UNBRACKET(vec<1, glm::i8>), super_type.x), 0, (char*)"i8vec1.x" },
+	{ (char*)"x", T_BYTE, offsetof(vec1_int8_t, super_type.x), 0, (char*)"i8vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi8vec1_methods[] = {

--- a/PyGLM/types/vec/int8/vec2.h
+++ b/PyGLM/types/vec/int8/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::i8> vec2_int8_t;
+
 static PyMemberDef hi8vec2_members[] = {
-	{ (char*)"x", T_BYTE, offsetof(UNBRACKET(vec<2, glm::i8>), super_type.x), 0, (char*)"i8vec2.x" },
-	{ (char*)"y", T_BYTE, offsetof(UNBRACKET(vec<2, glm::i8>), super_type.y), 0, (char*)"i8vec2.y" },
+	{ (char*)"x", T_BYTE, offsetof(vec2_int8_t, super_type.x), 0, (char*)"i8vec2.x" },
+	{ (char*)"y", T_BYTE, offsetof(vec2_int8_t, super_type.y), 0, (char*)"i8vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi8vec2_methods[] = {

--- a/PyGLM/types/vec/int8/vec3.h
+++ b/PyGLM/types/vec/int8/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::i8> vec3_int8_t;
+
 static PyMemberDef hi8vec3_members[] = {
-	{ (char*)"x", T_BYTE, offsetof(UNBRACKET(vec<3, glm::i8>), super_type.x), 0, (char*)"i8vec3.x" },
-	{ (char*)"y", T_BYTE, offsetof(UNBRACKET(vec<3, glm::i8>), super_type.y), 0, (char*)"i8vec3.y" },
-	{ (char*)"z", T_BYTE, offsetof(UNBRACKET(vec<3, glm::i8>), super_type.z), 0, (char*)"i8vec3.z" },
+	{ (char*)"x", T_BYTE, offsetof(vec3_int8_t, super_type.x), 0, (char*)"i8vec3.x" },
+	{ (char*)"y", T_BYTE, offsetof(vec3_int8_t, super_type.y), 0, (char*)"i8vec3.y" },
+	{ (char*)"z", T_BYTE, offsetof(vec3_int8_t, super_type.z), 0, (char*)"i8vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi8vec3_methods[] = {

--- a/PyGLM/types/vec/int8/vec4.h
+++ b/PyGLM/types/vec/int8/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::i8> vec4_int8_t;
+
 static PyMemberDef hi8vec4_members[] = {
-	{ (char*)"x", T_BYTE, offsetof(UNBRACKET(vec<4, glm::i8>), super_type.x), 0, (char*)"i8vec4.x" },
-	{ (char*)"y", T_BYTE, offsetof(UNBRACKET(vec<4, glm::i8>), super_type.y), 0, (char*)"i8vec4.y" },
-	{ (char*)"z", T_BYTE, offsetof(UNBRACKET(vec<4, glm::i8>), super_type.z), 0, (char*)"i8vec4.z" },
-	{ (char*)"w", T_BYTE, offsetof(UNBRACKET(vec<4, glm::i8>), super_type.w), 0, (char*)"i8vec4.w" },
+	{ (char*)"x", T_BYTE, offsetof(vec4_int8_t, super_type.x), 0, (char*)"i8vec4.x" },
+	{ (char*)"y", T_BYTE, offsetof(vec4_int8_t, super_type.y), 0, (char*)"i8vec4.y" },
+	{ (char*)"z", T_BYTE, offsetof(vec4_int8_t, super_type.z), 0, (char*)"i8vec4.z" },
+	{ (char*)"w", T_BYTE, offsetof(vec4_int8_t, super_type.w), 0, (char*)"i8vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hi8vec4_methods[] = {

--- a/PyGLM/types/vec/uint16/vec1.h
+++ b/PyGLM/types/vec/uint16/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::u16> vec1_uint16_t;
+
 static PyMemberDef hu16vec1_members[] = {
-	{ (char*)"x", T_USHORT, offsetof(UNBRACKET(vec<1, glm::u16>), super_type.x), 0, (char*)"u16vec1.x" },
+	{ (char*)"x", T_USHORT, offsetof(vec1_uint16_t, super_type.x), 0, (char*)"u16vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu16vec1_methods[] = {

--- a/PyGLM/types/vec/uint16/vec2.h
+++ b/PyGLM/types/vec/uint16/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::u16> vec2_uint16_t;
+
 static PyMemberDef hu16vec2_members[] = {
-	{ (char*)"x", T_USHORT, offsetof(UNBRACKET(vec<2, glm::u16>), super_type.x), 0, (char*)"u16vec2.x" },
-	{ (char*)"y", T_USHORT, offsetof(UNBRACKET(vec<2, glm::u16>), super_type.y), 0, (char*)"u16vec2.y" },
+	{ (char*)"x", T_USHORT, offsetof(vec2_uint16_t, super_type.x), 0, (char*)"u16vec2.x" },
+	{ (char*)"y", T_USHORT, offsetof(vec2_uint16_t, super_type.y), 0, (char*)"u16vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu16vec2_methods[] = {

--- a/PyGLM/types/vec/uint16/vec3.h
+++ b/PyGLM/types/vec/uint16/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::u16> vec3_uint16_t;
+
 static PyMemberDef hu16vec3_members[] = {
-	{ (char*)"x", T_USHORT, offsetof(UNBRACKET(vec<3, glm::u16>), super_type.x), 0, (char*)"u16vec3.x" },
-	{ (char*)"y", T_USHORT, offsetof(UNBRACKET(vec<3, glm::u16>), super_type.y), 0, (char*)"u16vec3.y" },
-	{ (char*)"z", T_USHORT, offsetof(UNBRACKET(vec<3, glm::u16>), super_type.z), 0, (char*)"u16vec3.z" },
+	{ (char*)"x", T_USHORT, offsetof(vec3_uint16_t, super_type.x), 0, (char*)"u16vec3.x" },
+	{ (char*)"y", T_USHORT, offsetof(vec3_uint16_t, super_type.y), 0, (char*)"u16vec3.y" },
+	{ (char*)"z", T_USHORT, offsetof(vec3_uint16_t, super_type.z), 0, (char*)"u16vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu16vec3_methods[] = {

--- a/PyGLM/types/vec/uint16/vec4.h
+++ b/PyGLM/types/vec/uint16/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::u16> vec4_uint16_t;
+
 static PyMemberDef hu16vec4_members[] = {
-	{ (char*)"x", T_USHORT, offsetof(UNBRACKET(vec<4, glm::u16>), super_type.x), 0, (char*)"u16vec4.x" },
-	{ (char*)"y", T_USHORT, offsetof(UNBRACKET(vec<4, glm::u16>), super_type.y), 0, (char*)"u16vec4.y" },
-	{ (char*)"z", T_USHORT, offsetof(UNBRACKET(vec<4, glm::u16>), super_type.z), 0, (char*)"u16vec4.z" },
-	{ (char*)"w", T_USHORT, offsetof(UNBRACKET(vec<4, glm::u16>), super_type.w), 0, (char*)"u16vec4.w" },
+	{ (char*)"x", T_USHORT, offsetof(vec4_uint16_t, super_type.x), 0, (char*)"u16vec4.x" },
+	{ (char*)"y", T_USHORT, offsetof(vec4_uint16_t, super_type.y), 0, (char*)"u16vec4.y" },
+	{ (char*)"z", T_USHORT, offsetof(vec4_uint16_t, super_type.z), 0, (char*)"u16vec4.z" },
+	{ (char*)"w", T_USHORT, offsetof(vec4_uint16_t, super_type.w), 0, (char*)"u16vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu16vec4_methods[] = {

--- a/PyGLM/types/vec/uint32/vec1.h
+++ b/PyGLM/types/vec/uint32/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::u32> vec1_uint32_t;
+
 static PyMemberDef huvec1_members[] = {
-	{ (char*)"x", T_UINT, offsetof(UNBRACKET(vec<1, glm::u32>), super_type.x), 0, (char*)"uvec1.x" },
+	{ (char*)"x", T_UINT, offsetof(vec1_uint32_t, super_type.x), 0, (char*)"uvec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef huvec1_methods[] = {

--- a/PyGLM/types/vec/uint32/vec2.h
+++ b/PyGLM/types/vec/uint32/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::u32> vec2_uint32_t;
+
 static PyMemberDef huvec2_members[] = {
-	{ (char*)"x", T_UINT, offsetof(UNBRACKET(vec<2, glm::u32>), super_type.x), 0, (char*)"uvec2.x" },
-	{ (char*)"y", T_UINT, offsetof(UNBRACKET(vec<2, glm::u32>), super_type.y), 0, (char*)"uvec2.y" },
+	{ (char*)"x", T_UINT, offsetof(vec2_uint32_t, super_type.x), 0, (char*)"uvec2.x" },
+	{ (char*)"y", T_UINT, offsetof(vec2_uint32_t, super_type.y), 0, (char*)"uvec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef huvec2_methods[] = {

--- a/PyGLM/types/vec/uint32/vec3.h
+++ b/PyGLM/types/vec/uint32/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::u32> vec3_uint32_t;
+
 static PyMemberDef huvec3_members[] = {
-	{ (char*)"x", T_UINT, offsetof(UNBRACKET(vec<3, glm::u32>), super_type.x), 0, (char*)"uvec3.x" },
-	{ (char*)"y", T_UINT, offsetof(UNBRACKET(vec<3, glm::u32>), super_type.y), 0, (char*)"uvec3.y" },
-	{ (char*)"z", T_UINT, offsetof(UNBRACKET(vec<3, glm::u32>), super_type.z), 0, (char*)"uvec3.z" },
+	{ (char*)"x", T_UINT, offsetof(vec3_uint32_t, super_type.x), 0, (char*)"uvec3.x" },
+	{ (char*)"y", T_UINT, offsetof(vec3_uint32_t, super_type.y), 0, (char*)"uvec3.y" },
+	{ (char*)"z", T_UINT, offsetof(vec3_uint32_t, super_type.z), 0, (char*)"uvec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef huvec3_methods[] = {

--- a/PyGLM/types/vec/uint32/vec4.h
+++ b/PyGLM/types/vec/uint32/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::u32> vec4_uint32_t;
+
 static PyMemberDef huvec4_members[] = {
-	{ (char*)"x", T_UINT, offsetof(UNBRACKET(vec<4, glm::u32>), super_type.x), 0, (char*)"uvec4.x" },
-	{ (char*)"y", T_UINT, offsetof(UNBRACKET(vec<4, glm::u32>), super_type.y), 0, (char*)"uvec4.y" },
-	{ (char*)"z", T_UINT, offsetof(UNBRACKET(vec<4, glm::u32>), super_type.z), 0, (char*)"uvec4.z" },
-	{ (char*)"w", T_UINT, offsetof(UNBRACKET(vec<4, glm::u32>), super_type.w), 0, (char*)"uvec4.w" },
+	{ (char*)"x", T_UINT, offsetof(vec4_uint32_t, super_type.x), 0, (char*)"uvec4.x" },
+	{ (char*)"y", T_UINT, offsetof(vec4_uint32_t, super_type.y), 0, (char*)"uvec4.y" },
+	{ (char*)"z", T_UINT, offsetof(vec4_uint32_t, super_type.z), 0, (char*)"uvec4.z" },
+	{ (char*)"w", T_UINT, offsetof(vec4_uint32_t, super_type.w), 0, (char*)"uvec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef huvec4_methods[] = {

--- a/PyGLM/types/vec/uint64/vec1.h
+++ b/PyGLM/types/vec/uint64/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::u64> vec1_uint64_t;
+
 static PyMemberDef hu64vec1_members[] = {
-	{ (char*)"x", T_ULONGLONG, offsetof(UNBRACKET(vec<1, glm::u64>), super_type.x), 0, (char*)"u64vec1.x" },
+	{ (char*)"x", T_ULONGLONG, offsetof(vec1_uint64_t, super_type.x), 0, (char*)"u64vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu64vec1_methods[] = {

--- a/PyGLM/types/vec/uint64/vec2.h
+++ b/PyGLM/types/vec/uint64/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::u64> vec2_uint64_t;
+
 static PyMemberDef hu64vec2_members[] = {
-	{ (char*)"x", T_ULONGLONG, offsetof(UNBRACKET(vec<2, glm::u64>), super_type.x), 0, (char*)"u64vec2.x" },
-	{ (char*)"y", T_ULONGLONG, offsetof(UNBRACKET(vec<2, glm::u64>), super_type.y), 0, (char*)"u64vec2.y" },
+	{ (char*)"x", T_ULONGLONG, offsetof(vec2_uint64_t, super_type.x), 0, (char*)"u64vec2.x" },
+	{ (char*)"y", T_ULONGLONG, offsetof(vec2_uint64_t, super_type.y), 0, (char*)"u64vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu64vec2_methods[] = {

--- a/PyGLM/types/vec/uint64/vec3.h
+++ b/PyGLM/types/vec/uint64/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::u64> vec3_uint64_t;
+
 static PyMemberDef hu64vec3_members[] = {
-	{ (char*)"x", T_ULONGLONG, offsetof(UNBRACKET(vec<3, glm::u64>), super_type.x), 0, (char*)"u64vec3.x" },
-	{ (char*)"y", T_ULONGLONG, offsetof(UNBRACKET(vec<3, glm::u64>), super_type.y), 0, (char*)"u64vec3.y" },
-	{ (char*)"z", T_ULONGLONG, offsetof(UNBRACKET(vec<3, glm::u64>), super_type.z), 0, (char*)"u64vec3.z" },
+	{ (char*)"x", T_ULONGLONG, offsetof(vec3_uint64_t, super_type.x), 0, (char*)"u64vec3.x" },
+	{ (char*)"y", T_ULONGLONG, offsetof(vec3_uint64_t, super_type.y), 0, (char*)"u64vec3.y" },
+	{ (char*)"z", T_ULONGLONG, offsetof(vec3_uint64_t, super_type.z), 0, (char*)"u64vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu64vec3_methods[] = {

--- a/PyGLM/types/vec/uint64/vec4.h
+++ b/PyGLM/types/vec/uint64/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::u64> vec4_uint64_t;
+
 static PyMemberDef hu64vec4_members[] = {
-	{ (char*)"x", T_ULONGLONG, offsetof(UNBRACKET(vec<4, glm::u64>), super_type.x), 0, (char*)"u64vec4.x" },
-	{ (char*)"y", T_ULONGLONG, offsetof(UNBRACKET(vec<4, glm::u64>), super_type.y), 0, (char*)"u64vec4.y" },
-	{ (char*)"z", T_ULONGLONG, offsetof(UNBRACKET(vec<4, glm::u64>), super_type.z), 0, (char*)"u64vec4.z" },
-	{ (char*)"w", T_ULONGLONG, offsetof(UNBRACKET(vec<4, glm::u64>), super_type.w), 0, (char*)"u64vec4.w" },
+	{ (char*)"x", T_ULONGLONG, offsetof(vec4_uint64_t, super_type.x), 0, (char*)"u64vec4.x" },
+	{ (char*)"y", T_ULONGLONG, offsetof(vec4_uint64_t, super_type.y), 0, (char*)"u64vec4.y" },
+	{ (char*)"z", T_ULONGLONG, offsetof(vec4_uint64_t, super_type.z), 0, (char*)"u64vec4.z" },
+	{ (char*)"w", T_ULONGLONG, offsetof(vec4_uint64_t, super_type.w), 0, (char*)"u64vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu64vec4_methods[] = {

--- a/PyGLM/types/vec/uint8/vec1.h
+++ b/PyGLM/types/vec/uint8/vec1.h
@@ -2,8 +2,10 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<1, glm::u8> vec1_uint8_t;
+
 static PyMemberDef hu8vec1_members[] = {
-	{ (char*)"x", T_UBYTE, offsetof(UNBRACKET(vec<1, glm::u8>), super_type.x), 0, (char*)"u8vec1.x" },
+	{ (char*)"x", T_UBYTE, offsetof(vec1_uint8_t, super_type.x), 0, (char*)"u8vec1.x" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu8vec1_methods[] = {

--- a/PyGLM/types/vec/uint8/vec2.h
+++ b/PyGLM/types/vec/uint8/vec2.h
@@ -2,9 +2,11 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<2, glm::u8> vec2_uint8_t;
+
 static PyMemberDef hu8vec2_members[] = {
-	{ (char*)"x", T_UBYTE, offsetof(UNBRACKET(vec<2, glm::u8>), super_type.x), 0, (char*)"u8vec2.x" },
-	{ (char*)"y", T_UBYTE, offsetof(UNBRACKET(vec<2, glm::u8>), super_type.y), 0, (char*)"u8vec2.y" },
+	{ (char*)"x", T_UBYTE, offsetof(vec2_uint8_t, super_type.x), 0, (char*)"u8vec2.x" },
+	{ (char*)"y", T_UBYTE, offsetof(vec2_uint8_t, super_type.y), 0, (char*)"u8vec2.y" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu8vec2_methods[] = {

--- a/PyGLM/types/vec/uint8/vec3.h
+++ b/PyGLM/types/vec/uint8/vec3.h
@@ -2,10 +2,12 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<3, glm::u8> vec3_uint8_t;
+
 static PyMemberDef hu8vec3_members[] = {
-	{ (char*)"x", T_UBYTE, offsetof(UNBRACKET(vec<3, glm::u8>), super_type.x), 0, (char*)"u8vec3.x" },
-	{ (char*)"y", T_UBYTE, offsetof(UNBRACKET(vec<3, glm::u8>), super_type.y), 0, (char*)"u8vec3.y" },
-	{ (char*)"z", T_UBYTE, offsetof(UNBRACKET(vec<3, glm::u8>), super_type.z), 0, (char*)"u8vec3.z" },
+	{ (char*)"x", T_UBYTE, offsetof(vec3_uint8_t, super_type.x), 0, (char*)"u8vec3.x" },
+	{ (char*)"y", T_UBYTE, offsetof(vec3_uint8_t, super_type.y), 0, (char*)"u8vec3.y" },
+	{ (char*)"z", T_UBYTE, offsetof(vec3_uint8_t, super_type.z), 0, (char*)"u8vec3.z" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu8vec3_methods[] = {

--- a/PyGLM/types/vec/uint8/vec4.h
+++ b/PyGLM/types/vec/uint8/vec4.h
@@ -2,11 +2,13 @@
 
 #include "../forward_declarations.h"
 
+typedef vec<4, glm::u8> vec4_uint8_t;
+
 static PyMemberDef hu8vec4_members[] = {
-	{ (char*)"x", T_UBYTE, offsetof(UNBRACKET(vec<4, glm::u8>), super_type.x), 0, (char*)"u8vec4.x" },
-	{ (char*)"y", T_UBYTE, offsetof(UNBRACKET(vec<4, glm::u8>), super_type.y), 0, (char*)"u8vec4.y" },
-	{ (char*)"z", T_UBYTE, offsetof(UNBRACKET(vec<4, glm::u8>), super_type.z), 0, (char*)"u8vec4.z" },
-	{ (char*)"w", T_UBYTE, offsetof(UNBRACKET(vec<4, glm::u8>), super_type.w), 0, (char*)"u8vec4.w" },
+	{ (char*)"x", T_UBYTE, offsetof(vec4_uint8_t, super_type.x), 0, (char*)"u8vec4.x" },
+	{ (char*)"y", T_UBYTE, offsetof(vec4_uint8_t, super_type.y), 0, (char*)"u8vec4.y" },
+	{ (char*)"z", T_UBYTE, offsetof(vec4_uint8_t, super_type.z), 0, (char*)"u8vec4.z" },
+	{ (char*)"w", T_UBYTE, offsetof(vec4_uint8_t, super_type.w), 0, (char*)"u8vec4.w" },
 	{ NULL }  /* Sentinel */
 };
 static PyMethodDef hu8vec4_methods[] = {

--- a/glm/glm/gtc/random.inl
+++ b/glm/glm/gtc/random.inl
@@ -228,7 +228,7 @@ namespace detail
 			w = x1 * x1 + x2 * x2;
 		} while(w > genType(1));
 
-		return static_cast<genType>(x2 * Deviation * Deviation * sqrt((genType(-2) * log(w)) / w) + Mean);
+		return static_cast<genType>(x2 * Deviation * Deviation * sqrt(((double) genType(-2) * log(w)) / w) + Mean);
 	}
 
 	template<length_t L, typename T, qualifier Q>


### PR DESCRIPTION
The 'UNBRACKET' macro (defined in `PyGLM/compiler_setup.h`) doesn't seem to work everywhere with clang 10.0.1 (on FreeBSD 12.2-RELEASE), so replaced by types.

Also added explicit cast to silence warning.