### PR TITLE
Don't require input matrix for rotate, translate and scale

### DIFF
--- a/PyGLM/functions/stable_extensions/matrix_transform.h
+++ b/PyGLM/functions/stable_extensions/matrix_transform.h
@@ -126,14 +126,83 @@ identity_(PyObject*, PyObject* arg) {
 	return NULL;
 }
 
-PyGLM_MAKE_GLM_FUNC_M3V2_M4V3__tfF(translate)
+static PyObject*
+translate_(PyObject*, PyObject* args) {
+	PyObject *arg1, *arg2 = NULL;
+	if (!PyArg_UnpackTuple(args, "translate", 1, 2, &arg1, &arg2)) return NULL;
+	if (arg2 == NULL) {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_DT_NORMAL);
+		if (PyGLM_Vec_PTI_Check0(3, float, arg1)) {
+			return pack(glm::translate(glm::mat<4, 4, float>(1), PyGLM_Vec_PTI_Get0(3, float, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, double, arg1)) {
+			return pack(glm::translate(glm::mat<4, 4, double>(1), PyGLM_Vec_PTI_Get0(3, double, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, int32, arg1)) {
+			return pack(glm::translate(glm::mat<4, 4, int32>(1), PyGLM_Vec_PTI_Get0(3, int32, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, uint32, arg1)) {
+			return pack(glm::translate(glm::mat<4, 4, uint32>(1), PyGLM_Vec_PTI_Get0(3, uint32, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, float, arg1)) {
+			return pack(glm::translate(glm::mat<3, 3, float>(1), PyGLM_Vec_PTI_Get0(2, float, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, double, arg1)) {
+			return pack(glm::translate(glm::mat<3, 3, double>(1), PyGLM_Vec_PTI_Get0(2, double, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, int32, arg1)) {
+			return pack(glm::translate(glm::mat<3, 3, int32>(1), PyGLM_Vec_PTI_Get0(2, int32, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, uint32, arg1)) {
+			return pack(glm::translate(glm::mat<3, 3, uint32>(1), PyGLM_Vec_PTI_Get0(2, uint32, arg1)));
+		}
+	}
+	else {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_MAT | PyGLM_SHAPE_3x3 | PyGLM_SHAPE_4x4 | PyGLM_DT_NORMAL);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_DT_NORMAL);
+		if (PyGLM_Mat_PTI_Check0(4, 4, float, arg1) && PyGLM_Vec_PTI_Check1(3, float, arg2)) {
+			return pack(glm::translate(PyGLM_Mat_PTI_Get0(4, 4, float, arg1), PyGLM_Vec_PTI_Get1(3, float, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(4, 4, double, arg1) && PyGLM_Vec_PTI_Check1(3, double, arg2)) {
+			return pack(glm::translate(PyGLM_Mat_PTI_Get0(4, 4, double, arg1), PyGLM_Vec_PTI_Get1(3, double, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(4, 4, int, arg1) && PyGLM_Vec_PTI_Check1(3, int, arg2)) {
+			return pack(glm::translate(PyGLM_Mat_PTI_Get0(4, 4, int, arg1), PyGLM_Vec_PTI_Get1(3, int, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(4, 4, uint32, arg1) && PyGLM_Vec_PTI_Check1(3, uint32, arg2)) {
+			return pack(glm::translate(PyGLM_Mat_PTI_Get0(4, 4, uint32, arg1), PyGLM_Vec_PTI_Get1(3, uint32, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(3, 3, float, arg1) && PyGLM_Vec_PTI_Check1(2, float, arg2)) {
+			return pack(glm::translate(PyGLM_Mat_PTI_Get0(3, 3, float, arg1), PyGLM_Vec_PTI_Get1(2, float, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(3, 3, double, arg1) && PyGLM_Vec_PTI_Check1(2, double, arg2)) {
+			return pack(glm::translate(PyGLM_Mat_PTI_Get0(3, 3, double, arg1), PyGLM_Vec_PTI_Get1(2, double, arg2)));
+		}
+	}
+	PyGLM_TYPEERROR_2O("invalid argument type(s) for translate(): ", arg1, arg2);
+	return NULL;
+}
 
 static PyObject*
 rotate_(PyObject*, PyObject* args) {
-	PyObject *arg1, *arg2, *arg3 = NULL;
-	if (!PyArg_UnpackTuple(args, "rotate", 2, 3, &arg1, &arg2, &arg3)) return NULL;
-	if (arg3 == NULL) {
-		if (PyGLM_Number_Check(arg2)) {
+	PyObject *arg1, *arg2 = NULL, *arg3 = NULL;
+	if (!PyArg_UnpackTuple(args, "rotate", 1, 3, &arg1, &arg2, &arg3)) return NULL;
+	if (arg2 == NULL) {
+		if (PyGLM_Number_Check(arg1)) {
+			return pack(glm::rotate(glm::mat3(1), PyGLM_Number_FromPyObject<float>(arg1)));
+		}
+	}
+	else if (arg3 == NULL) {
+		if (PyGLM_Number_Check(arg1)) {
+			PyGLM_PTI_Init0(arg2, PyGLM_T_VEC | PyGLM_SHAPE_3 | PyGLM_DT_FD);
+			if (PyGLM_Vec_PTI_Check0(3, float, arg2)) {
+				return pack(glm::rotate(glm::mat<4, 4, float>(1), PyGLM_Number_FromPyObject<float>(arg1), PyGLM_Vec_PTI_Get0(3, float, arg2)));
+			}
+			if (PyGLM_Vec_PTI_Check0(3, double, arg2)) {
+				return pack(glm::rotate(glm::mat<4, 4, double>(1), PyGLM_Number_FromPyObject<double>(arg1), PyGLM_Vec_PTI_Get0(3, double, arg2)));
+			}
+		}
+		else if (PyGLM_Number_Check(arg2)) {
 			PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_T_MAT | PyGLM_SHAPE_2 | PyGLM_SHAPE_3x3 | PyGLM_DT_FD);
 			if (PyGLM_Mat_PTI_Check0(3, 3, float, arg1)) {
 				glm::mat<3, 3, float> m = PyGLM_Mat_PTI_Get0(3, 3, float, arg1);
@@ -213,7 +282,63 @@ rotate_slow_(PyObject*, PyObject* args) {
 	return NULL;
 }
 
-PyGLM_MAKE_GLM_FUNC_M3V2_M4V3__tfF(scale)
+static PyObject*
+scale_(PyObject*, PyObject* args) {
+	PyObject* arg1, * arg2 = NULL;
+	if (!PyArg_UnpackTuple(args, "scale", 1, 2, &arg1, &arg2)) return NULL;
+	if (arg2 == NULL) {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_DT_NORMAL);
+		if (PyGLM_Vec_PTI_Check0(3, float, arg1)) {
+			return pack(glm::scale(glm::mat<4, 4, float>(1), PyGLM_Vec_PTI_Get0(3, float, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, double, arg1)) {
+			return pack(glm::scale(glm::mat<4, 4, double>(1), PyGLM_Vec_PTI_Get0(3, double, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, int32, arg1)) {
+			return pack(glm::scale(glm::mat<4, 4, int32>(1), PyGLM_Vec_PTI_Get0(3, int32, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, uint32, arg1)) {
+			return pack(glm::scale(glm::mat<4, 4, uint32>(1), PyGLM_Vec_PTI_Get0(3, uint32, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, float, arg1)) {
+			return pack(glm::scale(glm::mat<3, 3, float>(1), PyGLM_Vec_PTI_Get0(2, float, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, double, arg1)) {
+			return pack(glm::scale(glm::mat<3, 3, double>(1), PyGLM_Vec_PTI_Get0(2, double, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, int32, arg1)) {
+			return pack(glm::scale(glm::mat<3, 3, int32>(1), PyGLM_Vec_PTI_Get0(2, int32, arg1)));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, uint32, arg1)) {
+			return pack(glm::scale(glm::mat<3, 3, uint32>(1), PyGLM_Vec_PTI_Get0(2, uint32, arg1)));
+		}
+	}
+	else {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_MAT | PyGLM_SHAPE_3x3 | PyGLM_SHAPE_4x4 | PyGLM_DT_NORMAL);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_DT_NORMAL);
+		if (PyGLM_Mat_PTI_Check0(4, 4, float, arg1) && PyGLM_Vec_PTI_Check1(3, float, arg2)) {
+			return pack(glm::scale(PyGLM_Mat_PTI_Get0(4, 4, float, arg1), PyGLM_Vec_PTI_Get1(3, float, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(4, 4, double, arg1) && PyGLM_Vec_PTI_Check1(3, double, arg2)) {
+			return pack(glm::scale(PyGLM_Mat_PTI_Get0(4, 4, double, arg1), PyGLM_Vec_PTI_Get1(3, double, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(4, 4, int, arg1) && PyGLM_Vec_PTI_Check1(3, int, arg2)) {
+			return pack(glm::scale(PyGLM_Mat_PTI_Get0(4, 4, int, arg1), PyGLM_Vec_PTI_Get1(3, int, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(4, 4, uint32, arg1) && PyGLM_Vec_PTI_Check1(3, uint32, arg2)) {
+			return pack(glm::scale(PyGLM_Mat_PTI_Get0(4, 4, uint32, arg1), PyGLM_Vec_PTI_Get1(3, uint32, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(3, 3, float, arg1) && PyGLM_Vec_PTI_Check1(2, float, arg2)) {
+			return pack(glm::scale(PyGLM_Mat_PTI_Get0(3, 3, float, arg1), PyGLM_Vec_PTI_Get1(2, float, arg2)));
+		}
+		if (PyGLM_Mat_PTI_Check0(3, 3, double, arg1) && PyGLM_Vec_PTI_Check1(2, double, arg2)) {
+			return pack(glm::scale(PyGLM_Mat_PTI_Get0(3, 3, double, arg1), PyGLM_Vec_PTI_Get1(2, double, arg2)));
+		}
+	}
+	PyGLM_TYPEERROR_2O("invalid argument type(s) for scale(): ", arg1, arg2);
+	return NULL;
+}
+
 PyGLM_MAKE_GLM_FUNC_M4V3__tfF(scale_slow)
 
 
@@ -241,8 +366,13 @@ PyDoc_STRVAR(lookAtRH_docstr,
 	"	Build a right handed look at view matrix."
 );
 PyDoc_STRVAR(rotate_docstr,
+	"rotate(angle: number, axis: vec3) -> mat4x4\n"
+	"	Builds a rotation 4 x 4 matrix created from an axis vector and an angle.\n"
+	"rotate(angle: number) -> mat3x3\n"
+	"	Builds a rotation 3 x 3 matrix created from an angle.\n"
 	"rotate(m: mat4x4, angle: number, axis: vec3) -> mat4x4\n"
 	"	Builds a rotation 4 x 4 matrix created from an axis vector and an angle.\n"
+	"	`m` is the input matrix multiplied by this translation matrix\n"
 	"rotate(m: mat3x3, angle: number) -> mat3x3\n"
 	"	Builds a rotation 3 x 3 matrix created from an angle.\n"
 	"	`m` is the input matrix multiplied by this translation matrix\n"
@@ -256,15 +386,25 @@ PyDoc_STRVAR(rotate_docstr,
 	"	Rotates a quaternion from a vector of 3 components axis and an angle."
 );
 PyDoc_STRVAR(scale_docstr,
+	"scale(v: vec3) -> mat4x4\n"
+	"	Builds a scale 4 x 4 matrix created from 3 scalars.\n"
+	"scale(v: vec2) -> mat3x3\n"
+	"	Builds a scale 3 x 3 matrix created from a vector of 2 components.\n"
 	"scale(m: mat4x4, v: vec3) -> mat4x4\n"
 	"	Builds a scale 4 x 4 matrix created from 3 scalars.\n"
+	"	`m` is the input matrix multiplied by this translation matrix\n"
 	"scale(m: mat3x3, v: vec2) -> mat3x3\n"
 	"	Builds a scale 3 x 3 matrix created from a vector of 2 components.\n"
 	"	`m` is the input matrix multiplied by this translation matrix"
 );
 PyDoc_STRVAR(translate_docstr,
+	"translate(v: vec3) -> mat4x4\n"
+	"	Builds a translation 4 x 4 matrix created from a vector of 3 components.\n"
+	"translate(v: vec2) -> mat3x3\n"
+	"	Builds a translation 3 x 3 matrix created from a vector of 2 components.\n"
 	"translate(m: mat4x4, v: vec3) -> mat4x4\n"
 	"	Builds a translation 4 x 4 matrix created from a vector of 3 components.\n"
+	"	`m` is the input matrix multiplied by this translation matrix\n"
 	"translate(m: mat3x3, v: vec2) -> mat3x3\n"
 	"	Builds a translation 3 x 3 matrix created from a vector of 2 components.\n"
 	"	`m` is the input matrix multiplied by this translation matrix"

--- a/wiki/function-reference/stable_extensions/matrix_transform.md
+++ b/wiki/function-reference/stable_extensions/matrix_transform.md
@@ -33,8 +33,15 @@ Defines functions that generate common transformation matrices\.
 &emsp;&emsp;Build a right handed look at view matrix\.  
   
 ### rotate\(\) function  
+#### <code>glm.<code>**rotate**(**angle**: *number*, **axis**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
+  
+#### <code>glm.<code>**rotate**(**angle**: *number*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a rotation 3 x 3 matrix created from an angle\.  
+  
 #### <code>glm.<code>**rotate**(**m**: *mat4x4*, **angle**: *number*, **axis**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**rotate**(**m**: *mat3x3*, **angle**: *number*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a rotation 3 x 3 matrix created from an angle\.  
@@ -57,8 +64,15 @@ Defines functions that generate common transformation matrices\.
 &emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
   
 ### scale\(\) function  
+#### <code>glm.<code>**scale**(**v**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a scale 4 x 4 matrix created from 3 scalars\.  
+  
+#### <code>glm.<code>**scale**(**v**: *vec2*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a scale 3 x 3 matrix created from a vector of 2 components\.  
+  
 #### <code>glm.<code>**scale**(**m**: *mat4x4*, **v**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a scale 4 x 4 matrix created from 3 scalars\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**scale**(**m**: *mat3x3*, **v**: *vec2*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a scale 3 x 3 matrix created from a vector of 2 components\.  
@@ -69,8 +83,15 @@ Defines functions that generate common transformation matrices\.
 &emsp;&emsp;Builds a scale 4 x 4 matrix created from 3 scalars\.  
   
 ### translate\(\) function  
+#### <code>glm.<code>**translate**(**v**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a translation 4 x 4 matrix created from a vector of 3 components\.  
+  
+#### <code>glm.<code>**translate**(**v**: *vec2*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a translation 3 x 3 matrix created from a vector of 2 components\.  
+  
 #### <code>glm.<code>**translate**(**m**: *mat4x4*, **v**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a translation 4 x 4 matrix created from a vector of 3 components\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**translate**(**m**: *mat3x3*, **v**: *vec2*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a translation 3 x 3 matrix created from a vector of 2 components\.  

--- a/wiki/function-reference/stable_extensions/matrix_transform.sb
+++ b/wiki/function-reference/stable_extensions/matrix_transform.sb
@@ -31,8 +31,15 @@ Defines functions that generate common transformation matrices.
 \raw\&emsp;&emsp;\raw\Build a right handed look at view matrix.
 
 \h3\rotate() function\h3\
+\raw\#### <code>glm.<code>**rotate**(**angle**: *number*, **axis**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
+
+\raw\#### <code>glm.<code>**rotate**(**angle**: *number*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a rotation 3 x 3 matrix created from an angle.
+
 \raw\#### <code>glm.<code>**rotate**(**m**: *mat4x4*, **angle**: *number*, **axis**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**rotate**(**m**: *mat3x3*, **angle**: *number*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a rotation 3 x 3 matrix created from an angle.
@@ -55,8 +62,15 @@ Defines functions that generate common transformation matrices.
 \raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
 
 \h3\scale() function\h3\
+\raw\#### <code>glm.<code>**scale**(**v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a scale 4 x 4 matrix created from 3 scalars.
+
+\raw\#### <code>glm.<code>**scale**(**v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a scale 3 x 3 matrix created from a vector of 2 components.
+
 \raw\#### <code>glm.<code>**scale**(**m**: *mat4x4*, **v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a scale 4 x 4 matrix created from 3 scalars.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**scale**(**m**: *mat3x3*, **v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a scale 3 x 3 matrix created from a vector of 2 components.
@@ -67,8 +81,15 @@ Defines functions that generate common transformation matrices.
 \raw\&emsp;&emsp;\raw\Builds a scale 4 x 4 matrix created from 3 scalars.
 
 \h3\translate() function\h3\
+\raw\#### <code>glm.<code>**translate**(**v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a translation 4 x 4 matrix created from a vector of 3 components.
+
+\raw\#### <code>glm.<code>**translate**(**v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a translation 3 x 3 matrix created from a vector of 2 components.
+
 \raw\#### <code>glm.<code>**translate**(**m**: *mat4x4*, **v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a translation 4 x 4 matrix created from a vector of 3 components.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**translate**(**m**: *mat3x3*, **v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a translation 3 x 3 matrix created from a vector of 2 components.

--- a/wiki/function-reference/unstable_extensions/matrix_transform_2d.md
+++ b/wiki/function-reference/unstable_extensions/matrix_transform_2d.md
@@ -13,8 +13,15 @@ Defines functions that generate common 2d transformation matrices\.
 * [**translate** function](#translate-function)  
   
 ### rotate\(\) function  
+#### <code>glm.<code>**rotate**(**angle**: *number*, **axis**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
+  
+#### <code>glm.<code>**rotate**(**angle**: *number*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a rotation 3 x 3 matrix created from an angle\.  
+  
 #### <code>glm.<code>**rotate**(**m**: *mat4x4*, **angle**: *number*, **axis**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**rotate**(**m**: *mat3x3*, **angle**: *number*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a rotation 3 x 3 matrix created from an angle\.  
@@ -33,8 +40,15 @@ Defines functions that generate common 2d transformation matrices\.
 &emsp;&emsp;Rotates a quaternion from a vector of 3 components axis and an angle\.  
   
 ### scale\(\) function  
+#### <code>glm.<code>**scale**(**v**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a scale 4 x 4 matrix created from 3 scalars\.  
+  
+#### <code>glm.<code>**scale**(**v**: *vec2*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a scale 3 x 3 matrix created from a vector of 2 components\.  
+  
 #### <code>glm.<code>**scale**(**m**: *mat4x4*, **v**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a scale 4 x 4 matrix created from 3 scalars\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**scale**(**m**: *mat3x3*, **v**: *vec2*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a scale 3 x 3 matrix created from a vector of 2 components\.  
@@ -51,8 +65,15 @@ Defines functions that generate common 2d transformation matrices\.
 &emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 ### translate\(\) function  
+#### <code>glm.<code>**translate**(**v**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a translation 4 x 4 matrix created from a vector of 3 components\.  
+  
+#### <code>glm.<code>**translate**(**v**: *vec2*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a translation 3 x 3 matrix created from a vector of 2 components\.  
+  
 #### <code>glm.<code>**translate**(**m**: *mat4x4*, **v**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a translation 4 x 4 matrix created from a vector of 3 components\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**translate**(**m**: *mat3x3*, **v**: *vec2*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a translation 3 x 3 matrix created from a vector of 2 components\.  

--- a/wiki/function-reference/unstable_extensions/matrix_transform_2d.sb
+++ b/wiki/function-reference/unstable_extensions/matrix_transform_2d.sb
@@ -11,8 +11,15 @@ Defines functions that generate common 2d transformation matrices.
 \-\\url #translate-function\\b\translate\b\ function\url\
 \ul\
 \h3\rotate() function\h3\
+\raw\#### <code>glm.<code>**rotate**(**angle**: *number*, **axis**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
+
+\raw\#### <code>glm.<code>**rotate**(**angle**: *number*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a rotation 3 x 3 matrix created from an angle.
+
 \raw\#### <code>glm.<code>**rotate**(**m**: *mat4x4*, **angle**: *number*, **axis**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**rotate**(**m**: *mat3x3*, **angle**: *number*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a rotation 3 x 3 matrix created from an angle.
@@ -31,8 +38,15 @@ Defines functions that generate common 2d transformation matrices.
 \raw\&emsp;&emsp;\raw\Rotates a quaternion from a vector of 3 components axis and an angle.
 
 \h3\scale() function\h3\
+\raw\#### <code>glm.<code>**scale**(**v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a scale 4 x 4 matrix created from 3 scalars.
+
+\raw\#### <code>glm.<code>**scale**(**v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a scale 3 x 3 matrix created from a vector of 2 components.
+
 \raw\#### <code>glm.<code>**scale**(**m**: *mat4x4*, **v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a scale 4 x 4 matrix created from 3 scalars.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**scale**(**m**: *mat3x3*, **v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a scale 3 x 3 matrix created from a vector of 2 components.
@@ -49,8 +63,15 @@ Defines functions that generate common 2d transformation matrices.
 \raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \h3\translate() function\h3\
+\raw\#### <code>glm.<code>**translate**(**v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a translation 4 x 4 matrix created from a vector of 3 components.
+
+\raw\#### <code>glm.<code>**translate**(**v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a translation 3 x 3 matrix created from a vector of 2 components.
+
 \raw\#### <code>glm.<code>**translate**(**m**: *mat4x4*, **v**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a translation 4 x 4 matrix created from a vector of 3 components.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**translate**(**m**: *mat3x3*, **v**: *vec2*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a translation 3 x 3 matrix created from a vector of 2 components.

--- a/wiki/function-reference/unstable_extensions/rotate_vector.md
+++ b/wiki/function-reference/unstable_extensions/rotate_vector.md
@@ -18,8 +18,15 @@ Function to directly rotate a vector\.
 &emsp;&emsp;Build a rotation matrix from a normal and a up vector\.  
   
 ### rotate\(\) function  
+#### <code>glm.<code>**rotate**(**angle**: *number*, **axis**: *vec3*) -\> *mat4x4*</code></code>  
+&emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
+  
+#### <code>glm.<code>**rotate**(**angle**: *number*) -\> *mat3x3*</code></code>  
+&emsp;&emsp;Builds a rotation 3 x 3 matrix created from an angle\.  
+  
 #### <code>glm.<code>**rotate**(**m**: *mat4x4*, **angle**: *number*, **axis**: *vec3*) -\> *mat4x4*</code></code>  
 &emsp;&emsp;Builds a rotation 4 x 4 matrix created from an axis vector and an angle\.  
+&emsp;&emsp;``` m ``` is the input matrix multiplied by this translation matrix  
   
 #### <code>glm.<code>**rotate**(**m**: *mat3x3*, **angle**: *number*) -\> *mat3x3*</code></code>  
 &emsp;&emsp;Builds a rotation 3 x 3 matrix created from an angle\.  

--- a/wiki/function-reference/unstable_extensions/rotate_vector.sb
+++ b/wiki/function-reference/unstable_extensions/rotate_vector.sb
@@ -16,8 +16,15 @@ Function to directly rotate a vector.
 \raw\&emsp;&emsp;\raw\Build a rotation matrix from a normal and a up vector.
 
 \h3\rotate() function\h3\
+\raw\#### <code>glm.<code>**rotate**(**angle**: *number*, **axis**: *vec3*) -\\> *mat4x4*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
+
+\raw\#### <code>glm.<code>**rotate**(**angle**: *number*) -\\> *mat3x3*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Builds a rotation 3 x 3 matrix created from an angle.
+
 \raw\#### <code>glm.<code>**rotate**(**m**: *mat4x4*, **angle**: *number*, **axis**: *vec3*) -\\> *mat4x4*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a rotation 4 x 4 matrix created from an axis vector and an angle.
+\raw\&emsp;&emsp;\raw\\code\m\code\ is the input matrix multiplied by this translation matrix
 
 \raw\#### <code>glm.<code>**rotate**(**m**: *mat3x3*, **angle**: *number*) -\\> *mat3x3*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Builds a rotation 3 x 3 matrix created from an angle.


### PR DESCRIPTION
+ Created an overloaded variant of `rotate()`, `translate()` and `scale()`, that doesn't require the input matrix `m` (#139)