### PR TITLE
Added new tests and fixed some bugs

### DIFF
--- a/PyGLM/functions/detail/func_common.h
+++ b/PyGLM/functions/detail/func_common.h
@@ -24,7 +24,87 @@ PyDoc_STRVAR(sign_docstr,
 	"	For every component `c` of `x`:\n"
 	"	Returns `1.0` if `x > 0`, `0.0` if `x == 0`, or `-1.0` if `x < 0`."
 );
-PyGLM_MAKE_GLM_FUNC_N_V__tfF(sign)
+static PyObject*
+sign_(PyObject*, PyObject* arg) {
+	if (PyGLM_Number_Check(arg)) {
+		return pack(glm::sign(PyGLM_Number_FromPyObject<double>(arg)));
+	}
+	PyGLM_PTI_Init0(arg, PyGLM_T_ANY_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_FD | PyGLM_DT_INT | PyGLM_DT_INT64 | PyGLM_DT_INT16 | PyGLM_DT_INT8);
+	if (PyGLM_Vec_PTI_Check0(1, float, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(1, float, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(1, double, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(1, double, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(1, int32, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(1, int32, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(1, int64, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(1, int64, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(1, int16, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(1, int16, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(1, int8, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(1, int8, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(2, float, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(2, float, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(2, double, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(2, double, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(2, int32, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(2, int32, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(2, int64, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(2, int64, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(2, int16, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(2, int16, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(2, int8, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(2, int8, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(3, float, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(3, float, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(3, double, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(3, double, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(3, int32, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(3, int32, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(3, int64, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(3, int64, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(3, int16, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(3, int16, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(3, int8, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(3, int8, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(4, float, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(4, float, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(4, double, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(4, double, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(4, int32, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(4, int32, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(4, int64, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(4, int64, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(4, int16, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(4, int16, arg)));
+	}
+	if (PyGLM_Vec_PTI_Check0(4, int8, arg)) {
+		return pack(glm::sign(PyGLM_Vec_PTI_Get0(4, int8, arg)));
+	}
+	PyGLM_TYPEERROR_O("invalid argument type for sign(): ", arg);
+	return NULL;
+}
 
 PyDoc_STRVAR(floor_docstr,
 	"floor(x: float) -> float\n"
@@ -4260,7 +4340,6 @@ frexp_(PyObject*, PyObject* args) {
 	if (PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1) {
 		PyObject* arg = PyTuple_GET_ITEM(args, 0);
 		if (PyGLM_Number_Check(arg)) {
-			PyGLM_WARN(PyGLM_FREXP_WARNING, 1, "This function will return this pair: (m, e), which differs from glm behaviour.");
 			int e;
 			double m = glm::frexp(PyGLM_Number_FromPyObject<double>(arg), e);
 			return Py_BuildValue("(d, i)", m, e);

--- a/PyGLM/functions/detail/func_integer.h
+++ b/PyGLM/functions/detail/func_integer.h
@@ -7,45 +7,57 @@
 #include "../../internal_functions/all.h"
 
 PyDoc_STRVAR(uaddCarry_docstr,
+	"uaddCarry(x: int, y: int) -> (result: int, carry: int)\n"
+	"	Adds 32-bit unsigned integer `x` and `y`, returning the `sum` modulo `pow(2, 32)`. The value carry\n"
+	"	is set to `0` if the `sum` was less than `pow(2, 32)`, or to `1` otherwise.\n"
 	"uaddCarry(x: uvecN, y: uvecN, carry: uvecN) -> uvecN\n"
 	"	Adds 32-bit unsigned integer `x` and `y`, returning the `sum` modulo `pow(2, 32)`. The value carry\n"
 	"	is set to `0` if the `sum` was less than `pow(2, 32)`, or to `1` otherwise."
 );
 static PyObject*
 uaddCarry_(PyObject*, PyObject* args) {
-	PyObject *arg1, *arg2, *arg3;
-	PyGLM_Arg_Unpack_3O(args, "uaddCarry", arg1, arg2, arg3);
-	if (PyGLM_Number_Check(arg1)) {
-		PyErr_SetString(PyExc_TypeError, "uaddCarry() doesn't accept integer inputs in PyGLM");
-		return NULL;
+	PyObject *arg1, *arg2, *arg3 = NULL;
+	if (!PyArg_UnpackTuple(args, "uaddCarry", 2, 3, &arg1, &arg2, &arg3)) return NULL;
+	if (arg3 == NULL) {
+		if (PyLong_Check(arg1) && PyLong_Check(arg2) ) {
+			glm::uint carry;
+			glm::uint result = glm::uaddCarry(_PyGLM_Long_As_Number_No_Error<glm::uint>(arg1), _PyGLM_Long_As_Number_No_Error<glm::uint>(arg2), carry);
+			return Py_BuildValue("(I,I)", result, carry);
+		}
 	}
-	PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
-	PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
-	if (PyGLM_Vec_PTI_Check0(1, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(1, glm::uint, arg2) && Py_TYPE(arg3) == &huvec1Type) {
-		glm::uvec1 o = PyGLM_Vec_PTI_Get0(1, glm::uint, arg1);
-		glm::uvec1 o2 = PyGLM_Vec_PTI_Get1(1, glm::uint, arg2);
-		return pack_vec(glm::uaddCarry(o, o2, ((vec<1, glm::uint>*)arg3)->super_type));
-	}
-	if (PyGLM_Vec_PTI_Check0(2, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(2, glm::uint, arg2) && Py_TYPE(arg3) == &huvec2Type) {
-		glm::uvec2 o = PyGLM_Vec_PTI_Get0(2, glm::uint, arg1);
-		glm::uvec2 o2 = PyGLM_Vec_PTI_Get1(2, glm::uint, arg2);
-		return pack_vec(glm::uaddCarry(o, o2, ((vec<2, glm::uint>*)arg3)->super_type));
-	}
-	if (PyGLM_Vec_PTI_Check0(3, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(3, glm::uint, arg2) && Py_TYPE(arg3) == &huvec3Type) {
-		glm::uvec3 o = PyGLM_Vec_PTI_Get0(3, glm::uint, arg1);
-		glm::uvec3 o2 = PyGLM_Vec_PTI_Get1(3, glm::uint, arg2);
-		return pack_vec(glm::uaddCarry(o, o2, ((vec<3, glm::uint>*)arg3)->super_type));
-	}
-	if (PyGLM_Vec_PTI_Check0(4, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(4, glm::uint, arg2) && Py_TYPE(arg3) == &huvec4Type) {
-		glm::uvec4 o = PyGLM_Vec_PTI_Get0(4, glm::uint, arg1);
-		glm::uvec4 o2 = PyGLM_Vec_PTI_Get1(4, glm::uint, arg2);
-		return pack_vec(glm::uaddCarry(o, o2, ((vec<4, glm::uint>*)arg3)->super_type));
+	else {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
+		if (PyGLM_Vec_PTI_Check0(1, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(1, glm::uint, arg2) && Py_TYPE(arg3) == &huvec1Type) {
+			glm::uvec1 o = PyGLM_Vec_PTI_Get0(1, glm::uint, arg1);
+			glm::uvec1 o2 = PyGLM_Vec_PTI_Get1(1, glm::uint, arg2);
+			return pack_vec(glm::uaddCarry(o, o2, ((vec<1, glm::uint>*)arg3)->super_type));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(2, glm::uint, arg2) && Py_TYPE(arg3) == &huvec2Type) {
+			glm::uvec2 o = PyGLM_Vec_PTI_Get0(2, glm::uint, arg1);
+			glm::uvec2 o2 = PyGLM_Vec_PTI_Get1(2, glm::uint, arg2);
+			return pack_vec(glm::uaddCarry(o, o2, ((vec<2, glm::uint>*)arg3)->super_type));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(3, glm::uint, arg2) && Py_TYPE(arg3) == &huvec3Type) {
+			glm::uvec3 o = PyGLM_Vec_PTI_Get0(3, glm::uint, arg1);
+			glm::uvec3 o2 = PyGLM_Vec_PTI_Get1(3, glm::uint, arg2);
+			return pack_vec(glm::uaddCarry(o, o2, ((vec<3, glm::uint>*)arg3)->super_type));
+		}
+		if (PyGLM_Vec_PTI_Check0(4, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(4, glm::uint, arg2) && Py_TYPE(arg3) == &huvec4Type) {
+			glm::uvec4 o = PyGLM_Vec_PTI_Get0(4, glm::uint, arg1);
+			glm::uvec4 o2 = PyGLM_Vec_PTI_Get1(4, glm::uint, arg2);
+			return pack_vec(glm::uaddCarry(o, o2, ((vec<4, glm::uint>*)arg3)->super_type));
+		}
 	}
 	PyErr_SetString(PyExc_TypeError, "invalid argument type(s) for uaddCarry()");
 	return NULL;
 }
 
 PyDoc_STRVAR(usubBorrow_docstr,
+	"usubBorrow(x: int, y: int) -> (result: int, borrow: int)\n"
+	"	Subtracts the 32-bit unsigned integer `y` from `x`, returning the difference if non-negative,\n"
+	"	or `pow(2, 32)` plus the difference otherwise. The value borrow is set to `0` if `x >= y`, or to\n"
+	"	`1` otherwise.\n"
 	"usubBorrow(x: uvecN, y: uvecN, borrow: uvecN) -> uvecN\n"
 	"	Subtracts the 32-bit unsigned integer `y` from `x`, returning the difference if non-negative,\n"
 	"	or `pow(2, 32)` plus the difference otherwise. The value borrow is set to `0` if `x >= y`, or to\n"
@@ -53,132 +65,155 @@ PyDoc_STRVAR(usubBorrow_docstr,
 );
 static PyObject*
 usubBorrow_(PyObject*, PyObject* args) {
-	PyObject *arg1, *arg2, *arg3;
-	PyGLM_Arg_Unpack_3O(args, "usubBorrow", arg1, arg2, arg3);
-	if (PyGLM_Number_Check(arg1)) {
-		PyErr_SetString(PyExc_TypeError, "usubBorrow() doesn't accept integer inputs in PyGLM");
-		return NULL;
+	PyObject *arg1, *arg2, *arg3 = NULL;
+	if (!PyArg_UnpackTuple(args, "usubBorrow", 2, 3, &arg1, &arg2, &arg3)) return NULL;
+	if (arg3 == NULL) {
+		if (PyLong_Check(arg1) && PyLong_Check(arg2)) {
+			glm::uint borrow;
+			glm::uint result = glm::usubBorrow(_PyGLM_Long_As_Number_No_Error<glm::uint>(arg1), _PyGLM_Long_As_Number_No_Error<glm::uint>(arg2), borrow);
+			return Py_BuildValue("(I,I)", result, borrow);
+		}
 	}
-	PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
-	PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
-	if (PyGLM_Vec_PTI_Check0(1, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(1, glm::uint, arg2) && Py_TYPE(arg3) == &huvec1Type) {
-		glm::uvec1 o = PyGLM_Vec_PTI_Get0(1, glm::uint, arg1);
-		glm::uvec1 o2 = PyGLM_Vec_PTI_Get1(1, glm::uint, arg2);
-		return pack_vec(glm::usubBorrow(o, o2, ((vec<1, glm::uint>*)arg3)->super_type));
-	}
-	if (PyGLM_Vec_PTI_Check0(2, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(2, glm::uint, arg2) && Py_TYPE(arg3) == &huvec2Type) {
-		glm::uvec2 o = PyGLM_Vec_PTI_Get0(2, glm::uint, arg1);
-		glm::uvec2 o2 = PyGLM_Vec_PTI_Get1(2, glm::uint, arg2);
-		return pack_vec(glm::usubBorrow(o, o2, ((vec<2, glm::uint>*)arg3)->super_type));
-	}
-	if (PyGLM_Vec_PTI_Check0(3, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(3, glm::uint, arg2) && Py_TYPE(arg3) == &huvec3Type) {
-		glm::uvec3 o = PyGLM_Vec_PTI_Get0(3, glm::uint, arg1);
-		glm::uvec3 o2 = PyGLM_Vec_PTI_Get1(3, glm::uint, arg2);
-		return pack_vec(glm::usubBorrow(o, o2, ((vec<3, glm::uint>*)arg3)->super_type));
-	}
-	if (PyGLM_Vec_PTI_Check0(4, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(4, glm::uint, arg2) && Py_TYPE(arg3) == &huvec4Type) {
-		glm::uvec4 o = PyGLM_Vec_PTI_Get0(4, glm::uint, arg1);
-		glm::uvec4 o2 = PyGLM_Vec_PTI_Get1(4, glm::uint, arg2);
-		return pack_vec(glm::usubBorrow(o, o2, ((vec<4, glm::uint>*)arg3)->super_type));
+	else {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
+		if (PyGLM_Vec_PTI_Check0(1, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(1, glm::uint, arg2) && Py_TYPE(arg3) == &huvec1Type) {
+			glm::uvec1 o = PyGLM_Vec_PTI_Get0(1, glm::uint, arg1);
+			glm::uvec1 o2 = PyGLM_Vec_PTI_Get1(1, glm::uint, arg2);
+			return pack_vec(glm::usubBorrow(o, o2, ((vec<1, glm::uint>*)arg3)->super_type));
+		}
+		if (PyGLM_Vec_PTI_Check0(2, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(2, glm::uint, arg2) && Py_TYPE(arg3) == &huvec2Type) {
+			glm::uvec2 o = PyGLM_Vec_PTI_Get0(2, glm::uint, arg1);
+			glm::uvec2 o2 = PyGLM_Vec_PTI_Get1(2, glm::uint, arg2);
+			return pack_vec(glm::usubBorrow(o, o2, ((vec<2, glm::uint>*)arg3)->super_type));
+		}
+		if (PyGLM_Vec_PTI_Check0(3, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(3, glm::uint, arg2) && Py_TYPE(arg3) == &huvec3Type) {
+			glm::uvec3 o = PyGLM_Vec_PTI_Get0(3, glm::uint, arg1);
+			glm::uvec3 o2 = PyGLM_Vec_PTI_Get1(3, glm::uint, arg2);
+			return pack_vec(glm::usubBorrow(o, o2, ((vec<3, glm::uint>*)arg3)->super_type));
+		}
+		if (PyGLM_Vec_PTI_Check0(4, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(4, glm::uint, arg2) && Py_TYPE(arg3) == &huvec4Type) {
+			glm::uvec4 o = PyGLM_Vec_PTI_Get0(4, glm::uint, arg1);
+			glm::uvec4 o2 = PyGLM_Vec_PTI_Get1(4, glm::uint, arg2);
+			return pack_vec(glm::usubBorrow(o, o2, ((vec<4, glm::uint>*)arg3)->super_type));
+		}
 	}
 	PyErr_SetString(PyExc_TypeError, "invalid argument type(s) for usubBorrow()");
 	return NULL;
 }
 
 PyDoc_STRVAR(umulExtended_docstr,
+	"umulExtended(x: int, y: int) -> (msb: int, lsb: int)\n"
+	"	Multiplies 32-bit integers `x` and `y`, producing a 64-bit result. The 32 least-significant\n"
+	"	bits are returned in `lsb`. The 32 most-significant bits are returned in `msb`.\n"
 	"umulExtended(x: uvecN, y: uvecN, msb: uvecN, lsb: uvecN) -> uvecN\n"
 	"	Multiplies 32-bit integers `x` and `y`, producing a 64-bit result. The 32 least-significant\n"
 	"	bits are returned in `lsb`. The 32 most-significant bits are returned in `msb`."
 );
 static PyObject*
 umulExtended_(PyObject*, PyObject* args) {
-	PyObject *arg1, *arg2, *arg3, *arg4;
-	PyGLM_Arg_Unpack_4O(args, "umulExtended", arg1, arg2, arg3, arg4);
-	if (PyGLM_Number_Check(arg1)) {
-		PyErr_SetString(PyExc_TypeError, "umulExtended() doesn't accept integer inputs in PyGLM");
-		return NULL;
+	PyObject *arg1, *arg2, *arg3 = NULL, *arg4 = NULL;
+	if (!PyArg_UnpackTuple(args, "umulExtended", 2, 4, &arg1, &arg2, &arg3, &arg4)) return NULL;
+	if (arg3 == NULL) {
+		if (PyLong_Check(arg1) && PyLong_Check(arg2)) {
+			glm::uint msb, lsb;
+			glm::umulExtended(_PyGLM_Long_As_Number_No_Error<glm::uint>(arg1), _PyGLM_Long_As_Number_No_Error<glm::uint>(arg2), msb, lsb);
+			return Py_BuildValue("(I,I)", msb, lsb);
+		}
 	}
-	PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
-	PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
-	if (PyGLM_Vec_PTI_Check0(1, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(1, glm::uint, arg2) && Py_TYPE(arg3) == &huvec1Type && Py_TYPE(arg4) == &huvec1Type) {
-		glm::uvec1 o = PyGLM_Vec_PTI_Get0(1, glm::uint, arg1);
-		glm::uvec1 o2 = PyGLM_Vec_PTI_Get1(1, glm::uint, arg2);
-		glm::umulExtended(o, o2, ((vec<1, glm::uint>*)arg3)->super_type, ((vec<1, glm::uint>*)arg4)->super_type);
-		Py_RETURN_NONE;
-	}
-	if (PyGLM_Vec_PTI_Check0(2, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(2, glm::uint, arg2) && Py_TYPE(arg3) == &huvec2Type && Py_TYPE(arg4) == &huvec2Type) {
-		glm::uvec2 o = PyGLM_Vec_PTI_Get0(2, glm::uint, arg1);
-		glm::uvec2 o2 = PyGLM_Vec_PTI_Get1(2, glm::uint, arg2);
-		glm::umulExtended(o, o2, ((vec<2, glm::uint>*)arg3)->super_type, ((vec<2, glm::uint>*)arg4)->super_type);
-		Py_RETURN_NONE;
-	}
-	if (PyGLM_Vec_PTI_Check0(3, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(3, glm::uint, arg2) && Py_TYPE(arg3) == &huvec3Type && Py_TYPE(arg4) == &huvec3Type) {
-		glm::uvec3 o = PyGLM_Vec_PTI_Get0(3, glm::uint, arg1);
-		glm::uvec3 o2 = PyGLM_Vec_PTI_Get1(3, glm::uint, arg2);
-		glm::umulExtended(o, o2, ((vec<3, glm::uint>*)arg3)->super_type, ((vec<3, glm::uint>*)arg4)->super_type);
-		Py_RETURN_NONE;
-	}
-	if (PyGLM_Vec_PTI_Check0(4, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(4, glm::uint, arg2) && Py_TYPE(arg3) == &huvec4Type && Py_TYPE(arg4) == &huvec4Type) {
-		glm::uvec4 o = PyGLM_Vec_PTI_Get0(4, glm::uint, arg1);
-		glm::uvec4 o2 = PyGLM_Vec_PTI_Get1(4, glm::uint, arg2);
-		glm::umulExtended(o, o2, ((vec<4, glm::uint>*)arg3)->super_type, ((vec<4, glm::uint>*)arg4)->super_type);
-		Py_RETURN_NONE;
+	else if (arg4 != NULL) {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_UINT);
+		if (PyGLM_Vec_PTI_Check0(1, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(1, glm::uint, arg2) && Py_TYPE(arg3) == &huvec1Type && Py_TYPE(arg4) == &huvec1Type) {
+			glm::uvec1 o = PyGLM_Vec_PTI_Get0(1, glm::uint, arg1);
+			glm::uvec1 o2 = PyGLM_Vec_PTI_Get1(1, glm::uint, arg2);
+			glm::umulExtended(o, o2, ((vec<1, glm::uint>*)arg3)->super_type, ((vec<1, glm::uint>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
+		if (PyGLM_Vec_PTI_Check0(2, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(2, glm::uint, arg2) && Py_TYPE(arg3) == &huvec2Type && Py_TYPE(arg4) == &huvec2Type) {
+			glm::uvec2 o = PyGLM_Vec_PTI_Get0(2, glm::uint, arg1);
+			glm::uvec2 o2 = PyGLM_Vec_PTI_Get1(2, glm::uint, arg2);
+			glm::umulExtended(o, o2, ((vec<2, glm::uint>*)arg3)->super_type, ((vec<2, glm::uint>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
+		if (PyGLM_Vec_PTI_Check0(3, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(3, glm::uint, arg2) && Py_TYPE(arg3) == &huvec3Type && Py_TYPE(arg4) == &huvec3Type) {
+			glm::uvec3 o = PyGLM_Vec_PTI_Get0(3, glm::uint, arg1);
+			glm::uvec3 o2 = PyGLM_Vec_PTI_Get1(3, glm::uint, arg2);
+			glm::umulExtended(o, o2, ((vec<3, glm::uint>*)arg3)->super_type, ((vec<3, glm::uint>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
+		if (PyGLM_Vec_PTI_Check0(4, glm::uint, arg1) && PyGLM_Vec_PTI_Check1(4, glm::uint, arg2) && Py_TYPE(arg3) == &huvec4Type && Py_TYPE(arg4) == &huvec4Type) {
+			glm::uvec4 o = PyGLM_Vec_PTI_Get0(4, glm::uint, arg1);
+			glm::uvec4 o2 = PyGLM_Vec_PTI_Get1(4, glm::uint, arg2);
+			glm::umulExtended(o, o2, ((vec<4, glm::uint>*)arg3)->super_type, ((vec<4, glm::uint>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
 	}
 	PyErr_SetString(PyExc_TypeError, "invalid argument type(s) for umulExtended()");
 	return NULL;
 }
 
 PyDoc_STRVAR(imulExtended_docstr,
+	"imulExtended(x: int, y: int) -> (msb: int, lsb: int)\n"
+	"	Multiplies 32-bit integers `x` and `y`, producing a 64-bit result. The 32 least-significant\n"
+	"	bits are returned in `lsb`. The 32 most-significant bits are returned in `msb`.\n"
 	"imulExtended(x: ivecN, y: ivecN, msb: ivecN, lsb: ivecN) -> ivecN\n"
 	"	Multiplies 32-bit integers `x` and `y`, producing a 64-bit result. The 32 least-significant\n"
 	"	bits are returned in `lsb`. The 32 most-significant bits are returned in `msb`."
 );
 static PyObject*
 imulExtended_(PyObject*, PyObject* args) {
-	PyObject *arg1, *arg2, *arg3, *arg4;
-	PyGLM_Arg_Unpack_4O(args, "imulExtended", arg1, arg2, arg3, arg4);
-	if (PyGLM_Number_Check(arg1)) {
-		PyErr_SetString(PyExc_TypeError, "imulExtended() doesn't accept integer inputs in PyGLM");
-		return NULL;
+	PyObject* arg1, * arg2, * arg3 = NULL, * arg4 = NULL;
+	if (!PyArg_UnpackTuple(args, "imulExtended", 2, 4, &arg1, &arg2, &arg3, &arg4)) return NULL;
+	if (arg3 == NULL) {
+		if (PyLong_Check(arg1) && PyLong_Check(arg2)) {
+			int msb, lsb;
+			glm::imulExtended(_PyGLM_Long_As_Number_No_Error<int>(arg1), _PyGLM_Long_As_Number_No_Error<int>(arg2), msb, lsb);
+			return Py_BuildValue("(i,i)", msb, lsb);
+		}
 	}
-	PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_INT);
-	PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_INT);
-	if (PyGLM_Vec_PTI_Check0(1, int, arg1) && PyGLM_Vec_PTI_Check1(1, int, arg2) && Py_TYPE(arg3) == &hivec1Type && Py_TYPE(arg4) == &hivec1Type) {
-		glm::ivec1 o = PyGLM_Vec_PTI_Get0(1, int, arg1);
-		glm::ivec1 o2 = PyGLM_Vec_PTI_Get1(1, int, arg2);
-		glm::imulExtended(o, o2, ((vec<1, int>*)arg3)->super_type, ((vec<1, int>*)arg4)->super_type);
-		Py_RETURN_NONE;
-	}
-	if (PyGLM_Vec_PTI_Check0(2, int, arg1) && PyGLM_Vec_PTI_Check1(2, int, arg2) && Py_TYPE(arg3) == &hivec2Type && Py_TYPE(arg4) == &hivec2Type) {
-		glm::ivec2 o = PyGLM_Vec_PTI_Get0(2, int, arg1);
-		glm::ivec2 o2 = PyGLM_Vec_PTI_Get1(2, int, arg2);
-		glm::imulExtended(o, o2, ((vec<2, int>*)arg3)->super_type, ((vec<2, int>*)arg4)->super_type);
-		Py_RETURN_NONE;
-	}
-	if (PyGLM_Vec_PTI_Check0(3, int, arg1) && PyGLM_Vec_PTI_Check1(3, int, arg2) && Py_TYPE(arg3) == &hivec3Type && Py_TYPE(arg4) == &hivec3Type) {
-		glm::ivec3 o = PyGLM_Vec_PTI_Get0(3, int, arg1);
-		glm::ivec3 o2 = PyGLM_Vec_PTI_Get1(3, int, arg2);
-		glm::imulExtended(o, o2, ((vec<3, int>*)arg3)->super_type, ((vec<3, int>*)arg4)->super_type);
-		Py_RETURN_NONE;
-	}
-	if (PyGLM_Vec_PTI_Check0(4, int, arg1) && PyGLM_Vec_PTI_Check1(4, int, arg2) && Py_TYPE(arg3) == &hivec4Type && Py_TYPE(arg4) == &hivec4Type) {
-		glm::ivec4 o = PyGLM_Vec_PTI_Get0(4, int, arg1);
-		glm::ivec4 o2 = PyGLM_Vec_PTI_Get1(4, int, arg2);
-		glm::imulExtended(o, o2, ((vec<4, int>*)arg3)->super_type, ((vec<4, int>*)arg4)->super_type);
-		Py_RETURN_NONE;
+	else if (arg4 != NULL) {
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_INT);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_INT);
+		if (PyGLM_Vec_PTI_Check0(1, int, arg1) && PyGLM_Vec_PTI_Check1(1, int, arg2) && Py_TYPE(arg3) == &hivec1Type && Py_TYPE(arg4) == &hivec1Type) {
+			glm::ivec1 o = PyGLM_Vec_PTI_Get0(1, int, arg1);
+			glm::ivec1 o2 = PyGLM_Vec_PTI_Get1(1, int, arg2);
+			glm::imulExtended(o, o2, ((vec<1, int>*)arg3)->super_type, ((vec<1, int>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
+		if (PyGLM_Vec_PTI_Check0(2, int, arg1) && PyGLM_Vec_PTI_Check1(2, int, arg2) && Py_TYPE(arg3) == &hivec2Type && Py_TYPE(arg4) == &hivec2Type) {
+			glm::ivec2 o = PyGLM_Vec_PTI_Get0(2, int, arg1);
+			glm::ivec2 o2 = PyGLM_Vec_PTI_Get1(2, int, arg2);
+			glm::imulExtended(o, o2, ((vec<2, int>*)arg3)->super_type, ((vec<2, int>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
+		if (PyGLM_Vec_PTI_Check0(3, int, arg1) && PyGLM_Vec_PTI_Check1(3, int, arg2) && Py_TYPE(arg3) == &hivec3Type && Py_TYPE(arg4) == &hivec3Type) {
+			glm::ivec3 o = PyGLM_Vec_PTI_Get0(3, int, arg1);
+			glm::ivec3 o2 = PyGLM_Vec_PTI_Get1(3, int, arg2);
+			glm::imulExtended(o, o2, ((vec<3, int>*)arg3)->super_type, ((vec<3, int>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
+		if (PyGLM_Vec_PTI_Check0(4, int, arg1) && PyGLM_Vec_PTI_Check1(4, int, arg2) && Py_TYPE(arg3) == &hivec4Type && Py_TYPE(arg4) == &hivec4Type) {
+			glm::ivec4 o = PyGLM_Vec_PTI_Get0(4, int, arg1);
+			glm::ivec4 o2 = PyGLM_Vec_PTI_Get1(4, int, arg2);
+			glm::imulExtended(o, o2, ((vec<4, int>*)arg3)->super_type, ((vec<4, int>*)arg4)->super_type);
+			Py_RETURN_NONE;
+		}
 	}
 	PyErr_SetString(PyExc_TypeError, "invalid argument type(s) for imulExtended()");
 	return NULL;
 }
 
 PyDoc_STRVAR(bitfieldExtract_docstr,
-	"bitfieldExtract(value: int, offset: int, bits: int) -> int\n"
+	"bitfieldExtract(value: ctypes, offset: int, bits: int) -> int\n"
 	"	Extracts bits `[offset, offset + bits - 1]` from value, returning them in the least\n"
 	"	significant bits of the result. For unsigned data types, the most significant bits of the\n"
 	"	result will be set to zero. For signed data types, the most significant bits will be set to\n"
 	"	the value of bit `offset + base - 1`. If `bits` is zero, the result will be zero. The result\n"
 	"	will be undefined if `offset` or `bits` is negative, or if the sum of `offset` and `bits` is\n"
 	"	greater than the number of bits used to store the operand.\n"
+	"	You can use `int32`, `uint32`, `int64` or `uint64` types to specify the number of bits and the\n"
+	"	sign.\n"
 	"bitfieldExtract(value: vecN, offset: int, bits: int) -> vecN\n"
 	"	Returns `bitfieldExtract(c, offset, bits)` for every component `c` of `value`."
 );
@@ -188,8 +223,41 @@ bitfieldExtract_(PyObject*, PyObject* args) {
 	PyGLM_Arg_Unpack_3O(args, "bitfieldExtract", arg1, arg2, arg3);
 	if (PyLong_Check(arg2) && PyLong_Check(arg3)) {
 		int i = (int)PyLong_AS_LONG(arg2), i2 = (int)PyLong_AS_LONG(arg3);
+		if (PyGLM_Ctypes_Check(arg1)) {
+			if (PyGLM_Ctypes_TypeCheck(arg1, int32)) {
+				return pack(glm::bitfieldExtract(PyGLM_Ctypes_Get(arg1, int32), i, i2));
+			}
+			if (PyGLM_Ctypes_TypeCheck(arg1, uint32)) {
+				return pack(glm::bitfieldExtract(PyGLM_Ctypes_Get(arg1, uint32), i, i2));
+			}
+			if (PyGLM_Ctypes_TypeCheck(arg1, int64)) {
+				return pack(glm::bitfieldExtract(PyGLM_Ctypes_Get(arg1, int64), i, i2));
+			}
+			if (PyGLM_Ctypes_TypeCheck(arg1, uint64)) {
+				return pack(glm::bitfieldExtract(PyGLM_Ctypes_Get(arg1, uint64), i, i2));
+			}
+		}
 		if (PyLong_Check(arg1)) {
-			return PyLong_FromLong(glm::bitfieldExtract(PyLong_AS_LONG(arg1), i, i2));
+
+			PyGLM_WARN_TYPE(PyGLM_ARGUMENT_DEPRECATION_WARNING, PyExc_DeprecationWarning, "Using bitfieldExtract(int, [...]) is deprecated. Please use ctypes-integers with 32 or 64 bits instead (e.g. glm.int32)");
+
+			int sign1 = PyLong_Sign(arg1);
+
+			int overflow;
+
+			if (sign1 == -1) {
+				long l = PyLong_AsLongAndOverflow(arg1, &overflow);
+				if (overflow) {
+					return pack(glm::bitfieldExtract(_PyGLM_Long_As_Number_No_Error<long long>(arg1), i, i2));
+				}
+				return pack(glm::bitfieldExtract(l, i, i2));
+			}
+
+			unsigned long ul = PyLong_AsUnsignedLongAndOverflow(arg1, &overflow);
+			if (overflow) {
+				return pack(glm::bitfieldExtract(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg1), i, i2));
+			}
+			return pack(glm::bitfieldExtract(ul, i, i2));
 		}
 		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I);
 		if (PyGLM_Vec_PTI_Check0(1, int32, arg1)) {
@@ -326,12 +394,14 @@ bitfieldExtract_(PyObject*, PyObject* args) {
 }
 
 PyDoc_STRVAR(bitfieldInsert_docstr,
-	"bitfieldInsert(base: int, insert: int, offset: int, bits: int) -> int\n"
+	"bitfieldInsert(base: ctypes, insert: ctypes, offset: int, bits: int) -> int\n"
 	"	Returns the insertion the bits least-significant bits of insert into base. The result will\n"
 	"	have `bits[offset, offset + bits - 1]` taken from `bits[0, bits - 1]` of `insert`, and all other\n"
 	"	bits taken directly from the corresponding bits of `base`. If `bits` is zero, the result will\n"
 	"	simply be `base`. The result will be undefined if `offset` or `bits` is negative, or if the sum of\n"
 	"	`offset` and `bits` is greater than the number of bits used to store the operand.\n"
+	"	You can use `int32`, `uint32`, `int64` or `uint64` types to specify the number of bits and the\n"
+	"	sign.\n"
 	"bitfieldInsert(base: vecN, insert: vecN, offset: int, bits: int) -> vecN\n"
 	"	Returns `bitfieldInsert(base[i], insert[i], offset, bits)` for every index `i`."
 );
@@ -341,8 +411,44 @@ bitfieldInsert_(PyObject*, PyObject* args) {
 	PyGLM_Arg_Unpack_4O(args, "bitfieldInsert", arg1, arg2, arg3, arg4);
 	if (PyLong_Check(arg3) && PyLong_Check(arg4)) {
 		int i = (int)PyLong_AS_LONG(arg3), i2 = (int)PyLong_AS_LONG(arg4);
+		if (PyGLM_Ctypes_Check(arg1) && PyGLM_Ctypes_Check(arg2)) {
+			if (PyGLM_Ctypes_TypeCheck(arg1, int32) && PyGLM_Ctypes_TypeCheck(arg2, int32)) {
+				return pack(glm::bitfieldInsert(PyGLM_Ctypes_Get(arg1, int32), PyGLM_Ctypes_Get(arg2, int32), i, i2));
+			}
+			if (PyGLM_Ctypes_TypeCheck(arg1, uint32) && PyGLM_Ctypes_TypeCheck(arg2, uint32)) {
+				return pack(glm::bitfieldInsert(PyGLM_Ctypes_Get(arg1, uint32), PyGLM_Ctypes_Get(arg2, uint32), i, i2));
+			}
+			if (PyGLM_Ctypes_TypeCheck(arg1, int64) && PyGLM_Ctypes_TypeCheck(arg2, int64)) {
+				return pack(glm::bitfieldInsert(PyGLM_Ctypes_Get(arg1, int64), PyGLM_Ctypes_Get(arg2, int64), i, i2));
+			}
+			if (PyGLM_Ctypes_TypeCheck(arg1, uint64) && PyGLM_Ctypes_TypeCheck(arg2, uint64)) {
+				return pack(glm::bitfieldInsert(PyGLM_Ctypes_Get(arg1, uint64), PyGLM_Ctypes_Get(arg2, uint64), i, i2));
+			}
+		}
 		if (PyLong_Check(arg1) && PyLong_Check(arg2)) {
-			return PyLong_FromLong(glm::bitfieldInsert(PyLong_AS_LONG(arg1), PyLong_AS_LONG(arg2), i, i2));
+
+			PyGLM_WARN_TYPE(PyGLM_ARGUMENT_DEPRECATION_WARNING, PyExc_DeprecationWarning, "Using bitfieldInsert(int, int, [...]) is deprecated. Please use ctypes-integers with 32 or 64 bits instead (e.g. glm.int32)");
+
+			int sign1 = PyLong_Sign(arg1);
+			int sign2 = PyLong_Sign(arg2);
+
+			int overflow1, overflow2;
+
+			if (sign1 == -1 || sign2 == -1) {
+				long l1 = PyLong_AsLongAndOverflow(arg1, &overflow1);
+				long l2 = PyLong_AsLongAndOverflow(arg2, &overflow2);
+				if (overflow1 || overflow2) {
+					return pack(glm::bitfieldInsert(_PyGLM_Long_As_Number_No_Error<long long>(arg1), _PyGLM_Long_As_Number_No_Error<long long>(arg2), i, i2));
+				}
+				return pack(glm::bitfieldInsert(l1, l2, i, i2));
+			}
+
+			unsigned long ul1 = PyLong_AsUnsignedLongAndOverflow(arg1, &overflow1);
+			unsigned long ul2 = PyLong_AsUnsignedLongAndOverflow(arg2, &overflow2);
+			if (overflow1 || overflow2) {
+				return pack(glm::bitfieldInsert(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg1), _PyGLM_Long_As_Number_No_Error<unsigned long long>(arg2), i, i2));
+			}
+			return pack(glm::bitfieldInsert(ul1, ul2, i, i2));
 		}
 		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I32 | PyGLM_DT_I64);
 		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I32 | PyGLM_DT_I64);
@@ -432,18 +538,52 @@ bitfieldInsert_(PyObject*, PyObject* args) {
 }
 
 PyDoc_STRVAR(bitfieldReverse_docstr,
-	"bitfieldReverse(value: int) -> int\n"
+	"bitfieldReverse(value: ctypes) -> int\n"
 	"	Returns the reversal of the bits of `value`. The bit numbered `n` of the result will be taken\n"
 	"	from `bit(bits - 1) - n` of `value`, where `bits` is the total number of bits used to represent\n"
-	"	`value`.\n"
+	"	`value`. You can use `int32`, `uint32`, `int64` or `uint64` types to specify the number of bits\n"
+	"	and the sign.\n"
 	"bitfieldReverse(value: vecN) -> vecN\n"
 	"	Returns the reversal of the bits of `value`. The bit numbered `n` of the result will be taken\n"
 	"	from `bit(bits - 1) - n` of `value`, where `bits` is the total number of bits used to represent\n"
 	"	`value`."
 );
 static PyObject* bitfieldReverse_(PyObject*, PyObject* arg) {
+	if (PyGLM_Ctypes_Check(arg)) {
+		if (PyGLM_Ctypes_TypeCheck(arg, int32)) {
+			return pack(glm::bitfieldReverse(PyGLM_Ctypes_Get(arg, int32)));
+		}
+		if (PyGLM_Ctypes_TypeCheck(arg, uint32)) {
+			return pack(glm::bitfieldReverse(PyGLM_Ctypes_Get(arg, uint32)));
+		}
+		if (PyGLM_Ctypes_TypeCheck(arg, int64)) {
+			return pack(glm::bitfieldReverse(PyGLM_Ctypes_Get(arg, int64)));
+		}
+		if (PyGLM_Ctypes_TypeCheck(arg, uint64)) {
+			return pack(glm::bitfieldReverse(PyGLM_Ctypes_Get(arg, uint64)));
+		}
+	}
 	if (PyLong_Check(arg)) {
-		return PyLong_FromLongLong(glm::bitfieldReverse(PyLong_AsLongLong(arg)));
+
+		PyGLM_WARN_TYPE(PyGLM_ARGUMENT_DEPRECATION_WARNING, PyExc_DeprecationWarning, "Using bitfieldReverse(int) is deprecated. Please use ctypes-integers with 32 or 64 bits instead (e.g. glm.int32)");
+
+		int sign1 = PyLong_Sign(arg);
+
+		int overflow;
+
+		if (sign1 == -1) {
+			long l = PyLong_AsLongAndOverflow(arg, &overflow);
+			if (overflow) {
+				return pack(glm::bitfieldReverse(_PyGLM_Long_As_Number_No_Error<long long>(arg)));
+			}
+			return pack(glm::bitfieldReverse(l));
+		}
+
+		unsigned long ul = PyLong_AsUnsignedLongAndOverflow(arg, &overflow);
+		if (overflow) {
+			return pack(glm::bitfieldReverse(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg)));
+		}
+		return pack(glm::bitfieldReverse(ul));
 	}
 	PyGLM_PTI_Init0(arg, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I32 | PyGLM_DT_I64);
 	if (PyGLM_Vec_PTI_Check0(1, int32, arg)) {
@@ -501,14 +641,30 @@ static PyObject* bitfieldReverse_(PyObject*, PyObject* arg) {
 PyDoc_STRVAR(bitCount_docstr,
 	"bitCount(v: int) -> int\n"
 	"	Returns the number of bits set to `1` in the binary representation of `value`.\n"
-	"bitCount(v: ivecN) -> ivecN\n"
+	"bitCount(v: vecN) -> ivecN\n"
 	"	For every component `c` of `v`:\n"
 	"	Returns the number of bits set to `1` in the binary representation of `c`."
 );
 static PyObject*
 bitCount_(PyObject*, PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		return PyLong_FromLong(glm::bitCount(PyLong_AS_LONG(arg)));
+		int sign1 = PyLong_Sign(arg);
+
+		int overflow;
+
+		if (sign1 == -1) {
+			long l = PyLong_AsLongAndOverflow(arg, &overflow);
+			if (overflow) {
+				return pack(glm::bitCount(_PyGLM_Long_As_Number_No_Error<long long>(arg)));
+			}
+			return pack(glm::bitCount(l));
+		}
+
+		unsigned long ul = PyLong_AsUnsignedLongAndOverflow(arg, &overflow);
+		if (overflow) {
+			return pack(glm::bitCount(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg)));
+		}
+		return pack(glm::bitCount(ul));
 	}
 	PyGLM_PTI_Init0(arg, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I);
 	if (PyGLM_Vec_PTI_Check0(1, int32, arg)) {
@@ -647,14 +803,30 @@ PyDoc_STRVAR(findLSB_docstr,
 	"findLSB(value: int) -> int\n"
 	"	Returns the bit number of the least significant bit set to `1` in the binary representation\n"
 	"	of `value`. If `value` is zero, `-1` will be returned.\n"
-	"findLSB(value: vecN) -> vecN\n"
+	"findLSB(value: vecN) -> ivecN\n"
 	"	Returns the bit number of the least significant bit set to `1` in the binary representation\n"
 	"	of `value`. If `value` is zero, `-1` will be returned."
 );
 static PyObject*
 findLSB_(PyObject*, PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		return PyLong_FromLong(glm::findLSB(PyLong_AS_LONG(arg)));
+		int sign1 = PyLong_Sign(arg);
+
+		int overflow;
+
+		if (sign1 == -1) {
+			long l = PyLong_AsLongAndOverflow(arg, &overflow);
+			if (overflow) {
+				return pack(glm::findLSB(_PyGLM_Long_As_Number_No_Error<long long>(arg)));
+			}
+			return pack(glm::findLSB(l));
+		}
+
+		unsigned long ul = PyLong_AsUnsignedLongAndOverflow(arg, &overflow);
+		if (overflow) {
+			return pack(glm::findLSB(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg)));
+		}
+		return pack(glm::findLSB(ul));
 	}
 	PyGLM_PTI_Init0(arg, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I);
 	if (PyGLM_Vec_PTI_Check0(1, int32, arg)) {
@@ -795,14 +967,30 @@ PyDoc_STRVAR(findMSB_docstr,
 	"	For positive integers, the result will be the bit number of the most significant bit set to\n"
 	"	`1`. For negative integers, the result will be the bit number of the most significant bit set\n"
 	"	to `0`. For a value of zero or negative one, `-1` will be returned.\n"
-	"findMSB(value: vecN) -> vecN\n"
+	"findMSB(value: vecN) -> ivecN\n"
 	"	Returns the bit number of the least significant bit set to `1` in the binary representation\n"
 	"	of `value`. If `value` is zero, `-1` will be returned."
 );
 static PyObject*
 findMSB_(PyObject*, PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		return PyLong_FromLong(glm::findMSB(PyLong_AS_LONG(arg)));
+		int sign1 = PyLong_Sign(arg);
+
+		int overflow;
+
+		if (sign1 == -1) {
+			long l = PyLong_AsLongAndOverflow(arg, &overflow);
+			if (overflow) {
+				return pack(glm::findMSB(_PyGLM_Long_As_Number_No_Error<long long>(arg)));
+			}
+			return pack(glm::findMSB(l));
+		}
+
+		unsigned long ul = PyLong_AsUnsignedLongAndOverflow(arg, &overflow);
+		if (overflow) {
+			return pack(glm::findMSB(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg)));
+		}
+		return pack(glm::findMSB(ul));
 	}
 	PyGLM_PTI_Init0(arg, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_I);
 	if (PyGLM_Vec_PTI_Check0(1, int32, arg)) {

--- a/PyGLM/functions/detail/func_vector_relational.h
+++ b/PyGLM/functions/detail/func_vector_relational.h
@@ -640,10 +640,20 @@ equal(PyObject*, PyObject* args) {
 
 	if (PyGLM_Number_Check(arg3)) {
 		if (PyGLM_Number_Check(arg1) && PyGLM_Number_Check(arg2)) {
-			pack(glm::equal(PyGLM_Number_FromPyObject<double>(arg1), PyGLM_Number_FromPyObject<double>(arg2), PyGLM_Number_FromPyObject<double>(arg3)));
+			return pack(glm::equal(PyGLM_Number_FromPyObject<double>(arg1), PyGLM_Number_FromPyObject<double>(arg2), PyGLM_Number_FromPyObject<double>(arg3)));
 		}
-		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_T_MAT | PyGLM_T_QUA | PyGLM_SHAPE_NxM | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_SHAPE_4 | PyGLM_DT_FD);
-		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_T_MAT | PyGLM_T_QUA | PyGLM_SHAPE_NxM | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_SHAPE_4 | PyGLM_DT_FD);
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_T_MAT | PyGLM_T_QUA | PyGLM_SHAPE_NxM | PyGLM_SHAPE_ALL | PyGLM_DT_FD);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_T_MAT | PyGLM_T_QUA | PyGLM_SHAPE_NxM | PyGLM_SHAPE_ALL | PyGLM_DT_FD);
+		if (PyGLM_Vec_PTI_Check0(1, float, arg1) && PyGLM_Vec_PTI_Check1(1, float, arg2)) {
+			glm::vec<1, float> o = PyGLM_Vec_PTI_Get0(1, float, arg1);
+			glm::vec<1, float> o2 = PyGLM_Vec_PTI_Get1(1, float, arg2);
+			return pack(glm::equal(o, o2, PyGLM_Number_FromPyObject<float>(arg3)));
+		}
+		if (PyGLM_Vec_PTI_Check0(1, double, arg1) && PyGLM_Vec_PTI_Check1(1, double, arg2)) {
+			glm::vec<1, double> o = PyGLM_Vec_PTI_Get0(1, double, arg1);
+			glm::vec<1, double> o2 = PyGLM_Vec_PTI_Get1(1, double, arg2);
+			return pack(glm::equal(o, o2, PyGLM_Number_FromPyObject<double>(arg3)));
+		}
 		if (PyGLM_Vec_PTI_Check0(2, float, arg1) && PyGLM_Vec_PTI_Check1(2, float, arg2)) {
 			glm::vec<2, float> o = PyGLM_Vec_PTI_Get0(2, float, arg1);
 			glm::vec<2, float> o2 = PyGLM_Vec_PTI_Get1(2, float, arg2);
@@ -779,7 +789,26 @@ equal(PyObject*, PyObject* args) {
 		PyErr_SetString(PyExc_TypeError, "invalid argument type(s) for equal()");
 		return NULL;
 	}
-	PyGLM_PTI_Init2(arg3, PyGLM_T_VEC | PyGLM_SHAPE_2 | PyGLM_SHAPE_3 | PyGLM_SHAPE_4 | PyGLM_DT_INT | PyGLM_DT_FD)
+	PyGLM_PTI_Init2(arg3, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_DT_INT | PyGLM_DT_FD);
+
+	if (PyGLM_Vec_PTI_Check2(1, int, arg3)) {
+		glm::vec<1, int> o3 = PyGLM_Vec_PTI_Get2(1, int, arg3);
+		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_SHAPE_1 | PyGLM_DT_FD);
+		PyGLM_PTI_Init1(arg2, PyGLM_T_VEC | PyGLM_SHAPE_1 | PyGLM_DT_FD);
+		if (PyGLM_Vec_PTI_Check0(1, float, arg1) && PyGLM_Vec_PTI_Check1(1, float, arg2)) {
+			glm::vec<1, float> o = PyGLM_Vec_PTI_Get0(1, float, arg1);
+			glm::vec<1, float> o2 = PyGLM_Vec_PTI_Get1(1, float, arg2);
+			return pack(glm::equal(o, o2, o3));
+		}
+		if (PyGLM_Vec_PTI_Check0(1, double, arg1) && PyGLM_Vec_PTI_Check1(1, double, arg2)) {
+			glm::vec<1, double> o = PyGLM_Vec_PTI_Get0(1, double, arg1);
+			glm::vec<1, double> o2 = PyGLM_Vec_PTI_Get1(1, double, arg2);
+			return pack(glm::equal(o, o2, o3));
+		}
+		PyErr_SetString(PyExc_TypeError, "invalid argument type(s) for equal()");
+		return NULL;
+	}
+
 	if (PyGLM_Vec_PTI_Check2(2, int, arg3)) {
 		glm::vec<2, int> o3 = PyGLM_Vec_PTI_Get2(2, int, arg3);
 		PyGLM_PTI_Init0(arg1, PyGLM_T_VEC | PyGLM_T_MAT | PyGLM_SHAPE_2 | PyGLM_SHAPE_2xM | PyGLM_DT_FD);

--- a/PyGLM/functions/other/binary.h
+++ b/PyGLM/functions/other/binary.h
@@ -12,7 +12,7 @@ binary_add(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "add", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.add is deprecated. Use operator.add instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.add is deprecated. Use operator.add instead");
 
 	return PyNumber_Add(arg1, arg2);
 }
@@ -26,7 +26,7 @@ binary_sub(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "sub", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.sub is deprecated. Use operator.sub instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.sub is deprecated. Use operator.sub instead");
 
 	return PyNumber_Subtract(arg1, arg2);
 }
@@ -40,7 +40,7 @@ binary_mul(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "mul", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.mul is deprecated. Use operator.mul instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.mul is deprecated. Use operator.mul instead");
 
 	return PyNumber_Multiply(arg1, arg2);
 }
@@ -54,7 +54,7 @@ binary_div(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "div", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.div is deprecated. Use operator.truediv instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.div is deprecated. Use operator.truediv instead");
 
 	return PyNumber_TrueDivide(arg1, arg2);
 }
@@ -68,7 +68,7 @@ binary_floordiv(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "floordiv", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.floordiv is deprecated. Use operator.floordiv instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.floordiv is deprecated. Use operator.floordiv instead");
 
 	return PyNumber_FloorDivide(arg1, arg2);
 }
@@ -82,7 +82,7 @@ binary_mod(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "mod", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.mod is deprecated. Use operator.mod instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.mod is deprecated. Use operator.mod instead");
 
 	return PyNumber_Remainder(arg1, arg2);
 }
@@ -96,7 +96,7 @@ binary_lshift(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "lshift", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.lshift is deprecated. Use operator.lshift instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.lshift is deprecated. Use operator.lshift instead");
 
 	return PyNumber_Lshift(arg1, arg2);
 }
@@ -110,7 +110,7 @@ binary_rshift(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "rshift", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.rshift is deprecated. Use operator.rshift instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.rshift is deprecated. Use operator.rshift instead");
 
 	return PyNumber_Rshift(arg1, arg2);
 }
@@ -124,7 +124,7 @@ binary_and(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "band", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.band is deprecated. Use operator.and_ instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.band is deprecated. Use operator.and_ instead");
 
 	return PyNumber_And(arg1, arg2);
 }
@@ -138,7 +138,7 @@ binary_xor(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "bxor", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.bxor is deprecated. Use operator.xor instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.bxor is deprecated. Use operator.xor instead");
 
 	return PyNumber_Xor(arg1, arg2);
 }
@@ -152,7 +152,7 @@ binary_or(PyObject*, PyObject* args) {
 	PyObject* arg1, * arg2;
 	PyGLM_Arg_Unpack_2O(args, "bor", arg1, arg2);
 
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.bor is deprecated. Use operator.or_ instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.bor is deprecated. Use operator.or_ instead");
 
 	return PyNumber_Or(arg1, arg2);
 }

--- a/PyGLM/functions/other/unary.h
+++ b/PyGLM/functions/other/unary.h
@@ -14,7 +14,7 @@ PyDoc_STRVAR(unary_pos_docstr,
 );
 static PyObject* 
 unary_pos(PyObject*, PyObject* arg) {
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.pos is deprecated. Use operator.pos instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.pos is deprecated. Use operator.pos instead");
 	return PyNumber_Positive(arg);
 }
 
@@ -24,7 +24,7 @@ PyDoc_STRVAR(unary_neg_docstr,
 );
 static PyObject*
 unary_neg(PyObject*, PyObject* arg) {
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.neg is deprecated. Use operator.neg instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.neg is deprecated. Use operator.neg instead");
 	return PyNumber_Negative(arg);
 }
 
@@ -34,7 +34,7 @@ PyDoc_STRVAR(unary_inv_docstr,
 );
 static PyObject*
 unary_inv(PyObject*, PyObject* arg) {
-	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, 4, PyExc_DeprecationWarning, "glm.inv is deprecated. Use operator.invert instead");
+	PyGLM_WARN_TYPE(PyGLM_OPERATOR_DEPRECATION_WARNING, PyExc_DeprecationWarning, "glm.inv is deprecated. Use operator.invert instead");
 	return PyNumber_Invert(arg);
 }
 

--- a/PyGLM/internal_functions/error_functions.h
+++ b/PyGLM/internal_functions/error_functions.h
@@ -8,7 +8,7 @@
 
 #define PyGLM_ZERO_DIVISION_ERROR PyErr_SetString(PyExc_ZeroDivisionError, "Whoopsie. Integers can't divide by zero (:")
 
-#define PyGLM_ZERO_DIVISION_ERROR_T(T) if (std::numeric_limits<T>::is_iec559) { PyGLM_WARN(PyGLM_FLOAT_ZERO_DIVISION_WARNING, 2, "Uh oh.. There is a float division by zero here. I hope that's intended!"); } else { PyGLM_ZERO_DIVISION_ERROR; return NULL; }
+#define PyGLM_ZERO_DIVISION_ERROR_T(T) if (std::numeric_limits<T>::is_iec559) { PyGLM_WARN(PyGLM_FLOAT_ZERO_DIVISION_WARNING, "Uh oh.. There is a float division by zero here. I hope that's intended!"); } else { PyGLM_ZERO_DIVISION_ERROR; return NULL; }
 
 #define PyGLM_Arg_Unpack_1O(args, name, arg1) if(!PyArg_UnpackTuple(args, name, 1, 1, &arg1)) return NULL
 #define PyGLM_Arg_Unpack_2O(args, name, arg1, arg2) if(!PyArg_UnpackTuple(args, name, 2, 2, &arg1, &arg2)) return NULL

--- a/PyGLM/internal_functions/helper_macros.h
+++ b/PyGLM/internal_functions/helper_macros.h
@@ -16,6 +16,10 @@
 
 #define PyGLM_TypeCheck(op, tp) (Py_TYPE(op) == tp) 
 
+#define PyGLM_Ctypes_TypeCheck(op, tp) PyGLM_TypeCheck(op, PyGLM_CTYPES_TYPE<tp>())
+
+#define PyGLM_Ctypes_Get(op, tp) (*reinterpret_cast<tp*>(reinterpret_cast<ctypes_helper*>(op)->b_ptr))
+
 #define PyGLM_FITS_IN_FLOAT(value) ((FLT_MAX >= value && value >= FLT_MIN) || (-FLT_MIN >= value && value >= -FLT_MAX))
 
 #define PyGLM_TupleOrList_Check(op) PyType_FastSubclass(Py_TYPE(op), (Py_TPFLAGS_TUPLE_SUBCLASS | Py_TPFLAGS_LIST_SUBCLASS))
@@ -27,9 +31,9 @@
 #define PyGLM_PREPROCESSOR_TOSTRING_ID(x)  #x
 #define PyGLM_PREPROCESSOR_TOSTRING(x)  PyGLM_PREPROCESSOR_TOSTRING_ID(x)
 
-#define PyGLM_WARN(flag, id, msg) PyGLM_WARN_TYPE(flag, id, PyExc_UserWarning, msg)
+#define PyGLM_WARN(id, msg) PyGLM_WARN_TYPE(id, PyExc_UserWarning, msg)
 
-#define PyGLM_WARN_TYPE(flag, id, type, msg) if (PyGLM_SHOW_WARNINGS & flag) PyErr_WarnEx(type, msg "\nYou can silence this warning by calling glm.silence(" PyGLM_PREPROCESSOR_TOSTRING(id) ")", 1)
+#define PyGLM_WARN_TYPE(id, type, msg) if (PyGLM_SHOW_WARNINGS & (1ull << id)) PyErr_WarnEx(type, msg "\nYou can silence this warning by calling glm.silence(" PyGLM_PREPROCESSOR_TOSTRING(id) ")", 1)
 
 #define PyGLM_free(ptr) PyMem_Free(ptr); ptr = NULL;
 

--- a/PyGLM/internal_functions/number_functions.h
+++ b/PyGLM/internal_functions/number_functions.h
@@ -27,16 +27,106 @@ bool PyGLM_TestNumber(PyObject* arg) {
 	return true;
 }
 
+unsigned long PyLong_AsUnsignedLongAndOverflow(PyObject* arg, int* overflow) {
+	unsigned long out = PyLong_AsUnsignedLong(arg);
+	if (PyErr_Occurred()) {
+		PyErr_Clear();
+		*overflow = 1;
+	}
+	else {
+		*overflow = 0;
+	}
+	return out;
+}
+
+unsigned long long PyLong_AsUnsignedLongLongAndOverflow(PyObject* arg, int* overflow) {
+	unsigned long long out = PyLong_AsUnsignedLongLong(arg);
+	if (PyErr_Occurred()) {
+		PyErr_Clear();
+		*overflow = 1;
+	}
+	else {
+		*overflow = 0;
+	}
+	return out;
+}
+
+int PyLong_Sign(PyObject* arg) {
+	int overflow;
+	long l = PyLong_AsLongAndOverflow(arg, &overflow);
+	if (overflow) {
+		return overflow;
+	}
+	return glm::sign(l);
+}
+
 #define PyGLM_COULD_BE_NUMBER(arg) (Py_TYPE(arg)->tp_as_number != NULL && (arg->ob_type->tp_as_number->nb_index != NULL || arg->ob_type->tp_as_number->nb_int != NULL || arg->ob_type->tp_as_number->nb_float != NULL))
 
 #define PyGLM_Number_Check(arg) (PyFloat_Check(arg) || PyLong_Check(arg) || PyBool_Check(arg) || (PyGLM_COULD_BE_NUMBER(arg) &&PyGLM_TestNumber(arg)))
+
+template<typename T>
+T _PyGLM_Long_As_Number_No_Error(PyObject* arg) {
+	if (std::numeric_limits<T>::is_iec559) {
+		int overflow;
+		long long ll;
+		ll = PyLong_AsLongLongAndOverflow(arg, &overflow);
+		if (overflow == 1) {
+			return static_cast<T>(_PyGLM_Long_As_Number_No_Error<unsigned long long>(arg));
+		}
+		else if (overflow == -1) {
+			return static_cast<T>(_PyGLM_Long_As_Number_No_Error<long long>(arg));
+		}
+		return static_cast<T>(ll);
+	}
+	if (std::is_same<T, long>::value) {
+		int overflow;
+		long l = PyLong_AsLongAndOverflow(arg, &overflow);
+		if (overflow) {
+			PyGLM_WARN(PyGLM_OVERFLOW_WARNING, "Integer overflow (or underflow) occured.");
+		}
+		else {
+			return static_cast<T>(l);
+		}
+	}
+	if (std::is_same<T, unsigned long>::value) {
+		unsigned long ul = PyLong_AsUnsignedLong(arg);
+		if (PyErr_Occurred()) {
+			PyErr_Clear();
+			PyGLM_WARN(PyGLM_OVERFLOW_WARNING, "Integer overflow (or underflow) occured.");
+		}
+		else {
+			return static_cast<T>(ul);
+		}
+	}
+	if (std::is_same<T, long long>::value) {
+		int overflow;
+		long long ll = PyLong_AsLongLongAndOverflow(arg, &overflow);
+		if (overflow) {
+			PyGLM_WARN(PyGLM_OVERFLOW_WARNING, "Integer overflow (or underflow) occured.");
+		}
+		else {
+			return static_cast<T>(ll);
+		}
+	}
+	if (std::is_same<T, unsigned long>::value) {
+		unsigned long long ull = PyLong_AsUnsignedLongLong(arg);
+		if (PyErr_Occurred()) {
+			PyErr_Clear();
+			PyGLM_WARN(PyGLM_OVERFLOW_WARNING, "Integer overflow (or underflow) occured.");
+		}
+		else {
+			return static_cast<T>(ull);
+		}
+	}
+	return static_cast<T>(PyLong_AsUnsignedLongLongMask(arg));
+}
 
 double PyGLM_Number_AsDouble(PyObject* arg) {
 	if (PyFloat_Check(arg)) {
 		return PyFloat_AS_DOUBLE(arg);
 	}
 	if (PyLong_Check(arg)) {
-		return PyLong_AsDouble(arg);
+		return _PyGLM_Long_As_Number_No_Error<double>(arg);
 	}
 	if (PyBool_Check(arg)) {
 		return (arg == Py_True) ? 1.0 : 0.0;
@@ -53,7 +143,7 @@ double PyGLM_Number_AsDouble(PyObject* arg) {
 
 long PyGLM_Number_AsLong(PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		return PyLong_AS_LONG(arg);
+		return _PyGLM_Long_As_Number_No_Error<long>(arg);
 	}
 	if (PyFloat_Check(arg)) {
 		return (long)PyFloat_AS_DOUBLE(arg);
@@ -73,13 +163,7 @@ long PyGLM_Number_AsLong(PyObject* arg) {
 
 unsigned long PyGLM_Number_AsUnsignedLong(PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		unsigned long out = PyLong_AsUnsignedLong(arg);
-		if (PyErr_Occurred() != NULL) {
-			PyErr_Clear();
-			int overflow;
-			out = static_cast<unsigned long>(PyLong_AsLongLongAndOverflow(arg, &overflow));
-		}
-		return out;
+		return _PyGLM_Long_As_Number_No_Error<unsigned long>(arg);
 	}
 	if (PyFloat_Check(arg)) {
 		return (unsigned long)PyFloat_AS_DOUBLE(arg);
@@ -99,7 +183,7 @@ unsigned long PyGLM_Number_AsUnsignedLong(PyObject* arg) {
 
 long long PyGLM_Number_AsLongLong(PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		return PyLong_AsLongLong(arg);
+		return _PyGLM_Long_As_Number_No_Error<long long>(arg);
 	}
 	if (PyFloat_Check(arg)) {
 		return (long long)PyFloat_AS_DOUBLE(arg);
@@ -119,13 +203,7 @@ long long PyGLM_Number_AsLongLong(PyObject* arg) {
 
 unsigned long long PyGLM_Number_AsUnsignedLongLong(PyObject* arg) {
 	if (PyLong_Check(arg)) {
-		unsigned long long out = PyLong_AsUnsignedLongLong(arg);
-		if (PyErr_Occurred() != NULL) {
-			PyErr_Clear();
-			int overflow;
-			out = static_cast<unsigned long long>(PyLong_AsLongLongAndOverflow(arg, &overflow));
-		}
-		return out;
+		return _PyGLM_Long_As_Number_No_Error<unsigned long long>(arg);
 	}
 	if (PyFloat_Check(arg)) {
 		return (unsigned long long)PyFloat_AS_DOUBLE(arg);
@@ -148,7 +226,7 @@ bool PyGLM_Number_AsBool(PyObject* arg) {
 		return (arg == Py_True) ? true : false;
 	}
 	if (PyLong_Check(arg)) {
-		return (bool)PyLong_AS_LONG(arg);
+		return _PyGLM_Long_As_Number_No_Error<bool>(arg);
 	}
 	if (PyFloat_Check(arg)) {
 		return (bool)PyFloat_AS_DOUBLE(arg);
@@ -168,7 +246,7 @@ float PyGLM_Number_AsFloat(PyObject* arg) {
 		return (float)PyFloat_AS_DOUBLE(arg);
 	}
 	if (PyLong_Check(arg)) {
-		return (float)PyLong_AS_LONG(arg);
+		return _PyGLM_Long_As_Number_No_Error<float>(arg);
 	}
 	if (PyBool_Check(arg)) {
 		return (arg == Py_True) ? 1.f : 0.f;

--- a/PyGLM/internal_functions/type_checkers.h
+++ b/PyGLM/internal_functions/type_checkers.h
@@ -2287,7 +2287,9 @@ private:
 
 #define	PyGLM_Is_PyGLM_Type(o) (((PyTypeObject*)(o))->tp_dealloc == (destructor)vec_dealloc || ((PyTypeObject*)(o))->tp_dealloc == (destructor)mvec_dealloc || ((PyTypeObject*)(o))->tp_dealloc == (destructor)mat_dealloc || ((PyTypeObject*)(o))->tp_dealloc == (destructor)qua_dealloc)
 
-#define PyGLM_Ctypes_Check(o) (((PyTypeObject*)(o))->tp_dealloc == ctypes_dealloc)
+#define PyGLM_Ctypes_CheckType(o) (((PyTypeObject*)(o))->tp_dealloc == ctypes_dealloc)
+
+#define PyGLM_Ctypes_Check(o) PyGLM_Ctypes_CheckType(Py_TYPE(o))
 
 #define PyGLM_Array_Check(o) (((PyTypeObject*)(o)) == &glmArrayType)
 

--- a/PyGLM/internal_functions/warnings.h
+++ b/PyGLM/internal_functions/warnings.h
@@ -2,10 +2,12 @@
 
 #include "error_functions.h"
 
-#define PyGLM_FREXP_WARNING					0x1
-#define PyGLM_FLOAT_ZERO_DIVISION_WARNING	0x2
-#define PyGLM_NO_REFERENCE_POSSIBLE_WARNING	0x4
-#define PyGLM_OPERATOR_DEPRECATION_WARNING	0x8
+#define PyGLM_FREXP_WARNING					1 // This warning is deprecated
+#define PyGLM_FLOAT_ZERO_DIVISION_WARNING	2
+#define PyGLM_NO_REFERENCE_POSSIBLE_WARNING	3
+#define PyGLM_OPERATOR_DEPRECATION_WARNING	4
+#define PyGLM_OVERFLOW_WARNING				5
+#define PyGLM_ARGUMENT_DEPRECATION_WARNING	6
 
 unsigned long long PyGLM_SHOW_WARNINGS = 18446744073709551615ull;
 
@@ -18,7 +20,7 @@ static PyObject*
 silence(PyObject*, PyObject* arg) {
 	if (PyLong_Check(arg)) {
 		unsigned long long warning_id = static_cast<unsigned long long>(PyLong_AS_LONG(arg));
-		if (warning_id < 0 || warning_id > 4) {
+		if (warning_id < 0 || warning_id > 6) {
 			PyErr_SetString(PyExc_ValueError, "the specified warning does not exist.");
 			return NULL;
 		}

--- a/PyGLM/type_methods/glmArray.h
+++ b/PyGLM/type_methods/glmArray.h
@@ -68,7 +68,7 @@ glmArray_from_bytes(PyObject*, PyObject* args) {
 			return (PyObject*)out;
 		}
 
-		if (PyGLM_Ctypes_Check(typeObj)) {
+		if (PyGLM_Ctypes_CheckType(typeObj)) {
 			glmArray* out = (glmArray*)glmArrayType.tp_alloc(&glmArrayType, 0);
 
 			if (out == NULL) {
@@ -197,7 +197,7 @@ glmArray_reinterpret_cast(glmArray* self, PyObject* arg) {
 			return (PyObject*)out;
 		}
 
-		if (PyGLM_Ctypes_Check(arg)) {
+		if (PyGLM_Ctypes_CheckType(arg)) {
 			glmArray* out = (glmArray*)glmArrayType.tp_alloc(&glmArrayType, 0);
 
 			if (out == NULL) {
@@ -1443,7 +1443,7 @@ glmArray_as_reference(PyObject*, PyObject* arg) {
 			int C = static_cast<int>(view.shape[2]);
 
 			if (view.strides[0] != view.itemsize * C * R || view.strides[1] != view.itemsize || view.strides[2] != view.itemsize * R) {
-				PyGLM_WARN(PyGLM_NO_REFERENCE_POSSIBLE_WARNING, 3, "The given array has an incompatible memory layout, therefore it will be copied!");
+				PyGLM_WARN(PyGLM_NO_REFERENCE_POSSIBLE_WARNING, "The given array has an incompatible memory layout, therefore it will be copied!");
 
 				Py_DECREF(out->reference);
 				out->reference = NULL;
@@ -2632,7 +2632,7 @@ glmArray_init(glmArray* self, PyObject* args, PyObject* kwds) {
 	}
 
 	// ctypes
-	if (PyGLM_Ctypes_Check(firstElementType)) {
+	if (PyGLM_Ctypes_CheckType(firstElementType)) {
 		GLM_ARRAY_INIT_IF_IS_CTYPES_TUPLE_OR_LIST(float);
 		GLM_ARRAY_INIT_IF_IS_CTYPES_TUPLE_OR_LIST(double);
 		GLM_ARRAY_INIT_IF_IS_CTYPES_TUPLE_OR_LIST(int8);
@@ -2972,7 +2972,7 @@ glmArray_init(glmArray* self, PyObject* args, PyObject* kwds) {
 			}
 
 			// ctypes
-			if (PyGLM_Ctypes_Check(firstElementType)) {
+			if (PyGLM_Ctypes_CheckType(firstElementType)) {
 				GLM_ARRAY_INIT_IF_IS_CTYPES_ITER(float);
 				GLM_ARRAY_INIT_IF_IS_CTYPES_ITER(double);
 				GLM_ARRAY_INIT_IF_IS_CTYPES_ITER(int8);

--- a/wiki/function-reference/detail/func_integer.md
+++ b/wiki/function-reference/detail/func_integer.md
@@ -21,38 +21,43 @@ It contains GLSL functions on integer types\.
 #### <code>glm.<code>**bitCount**(**v**: *int*) -\> *int*</code></code>  
 &emsp;&emsp;Returns the number of bits set to ``` 1 ``` in the binary representation of ``` value ```\.  
   
-#### <code>glm.<code>**bitCount**(**v**: *ivecN*) -\> *ivecN*</code></code>  
+#### <code>glm.<code>**bitCount**(**v**: *vecN*) -\> *ivecN*</code></code>  
 &emsp;&emsp;For every component ``` c ``` of ``` v ```:  
 &emsp;&emsp;Returns the number of bits set to ``` 1 ``` in the binary representation of ``` c ```\.  
   
 ### bitfieldExtract\(\) function  
-#### <code>glm.<code>**bitfieldExtract**(**value**: *int*, **offset**: *int*, **bits**: *int*) -\> *int*</code></code>  
+#### <code>glm.<code>**bitfieldExtract**(**value**: *ctypes*, **offset**: *int*, **bits**: *int*) -\> *int*</code></code>  
 &emsp;&emsp;Extracts bits ``` [offset, offset + bits - 1] ``` from value, returning them in the least  
 &emsp;&emsp;significant bits of the result\. For unsigned data types, the most significant bits of the  
 &emsp;&emsp;result will be set to zero\. For signed data types, the most significant bits will be set to  
 &emsp;&emsp;the value of bit ``` offset + base - 1 ```\. If ``` bits ``` is zero, the result will be zero\. The result  
 &emsp;&emsp;will be undefined if ``` offset ``` or ``` bits ``` is negative, or if the sum of ``` offset ``` and ``` bits ``` is  
 &emsp;&emsp;greater than the number of bits used to store the operand\.  
+&emsp;&emsp;You can use ``` int32 ```, ``` uint32 ```, ``` int64 ``` or ``` uint64 ``` types to specify the number of bits and the  
+&emsp;&emsp;sign\.  
   
 #### <code>glm.<code>**bitfieldExtract**(**value**: *vecN*, **offset**: *int*, **bits**: *int*) -\> *vecN*</code></code>  
 &emsp;&emsp;Returns ``` bitfieldExtract(c, offset, bits) ``` for every component ``` c ``` of ``` value ```\.  
   
 ### bitfieldInsert\(\) function  
-#### <code>glm.<code>**bitfieldInsert**(**base**: *int*, **insert**: *int*, **offset**: *int*, **bits**: *int*) -\> *int*</code></code>  
+#### <code>glm.<code>**bitfieldInsert**(**base**: *ctypes*, **insert**: *ctypes*, **offset**: *int*, **bits**: *int*) -\> *int*</code></code>  
 &emsp;&emsp;Returns the insertion the bits least\-significant bits of insert into base\. The result will  
 &emsp;&emsp;have ``` bits[offset, offset + bits - 1] ``` taken from ``` bits[0, bits - 1] ``` of ``` insert ```, and all other  
 &emsp;&emsp;bits taken directly from the corresponding bits of ``` base ```\. If ``` bits ``` is zero, the result will  
 &emsp;&emsp;simply be ``` base ```\. The result will be undefined if ``` offset ``` or ``` bits ``` is negative, or if the sum of  
 &emsp;&emsp;``` offset ``` and ``` bits ``` is greater than the number of bits used to store the operand\.  
+&emsp;&emsp;You can use ``` int32 ```, ``` uint32 ```, ``` int64 ``` or ``` uint64 ``` types to specify the number of bits and the  
+&emsp;&emsp;sign\.  
   
 #### <code>glm.<code>**bitfieldInsert**(**base**: *vecN*, **insert**: *vecN*, **offset**: *int*, **bits**: *int*) -\> *vecN*</code></code>  
 &emsp;&emsp;Returns ``` bitfieldInsert(base[i], insert[i], offset, bits) ``` for every index ``` i ```\.  
   
 ### bitfieldReverse\(\) function  
-#### <code>glm.<code>**bitfieldReverse**(**value**: *int*) -\> *int*</code></code>  
+#### <code>glm.<code>**bitfieldReverse**(**value**: *ctypes*) -\> *int*</code></code>  
 &emsp;&emsp;Returns the reversal of the bits of ``` value ```\. The bit numbered ``` n ``` of the result will be taken  
 &emsp;&emsp;from ``` bit(bits - 1) - n ``` of ``` value ```, where ``` bits ``` is the total number of bits used to represent  
-&emsp;&emsp;``` value ```\.  
+&emsp;&emsp;``` value ```\. You can use ``` int32 ```, ``` uint32 ```, ``` int64 ``` or ``` uint64 ``` types to specify the number of bits  
+&emsp;&emsp;and the sign\.  
   
 #### <code>glm.<code>**bitfieldReverse**(**value**: *vecN*) -\> *vecN*</code></code>  
 &emsp;&emsp;Returns the reversal of the bits of ``` value ```\. The bit numbered ``` n ``` of the result will be taken  
@@ -64,7 +69,7 @@ It contains GLSL functions on integer types\.
 &emsp;&emsp;Returns the bit number of the least significant bit set to ``` 1 ``` in the binary representation  
 &emsp;&emsp;of ``` value ```\. If ``` value ``` is zero, ``` -1 ``` will be returned\.  
   
-#### <code>glm.<code>**findLSB**(**value**: *vecN*) -\> *vecN*</code></code>  
+#### <code>glm.<code>**findLSB**(**value**: *vecN*) -\> *ivecN*</code></code>  
 &emsp;&emsp;Returns the bit number of the least significant bit set to ``` 1 ``` in the binary representation  
 &emsp;&emsp;of ``` value ```\. If ``` value ``` is zero, ``` -1 ``` will be returned\.  
   
@@ -75,26 +80,43 @@ It contains GLSL functions on integer types\.
 &emsp;&emsp;``` 1 ```\. For negative integers, the result will be the bit number of the most significant bit set  
 &emsp;&emsp;to ``` 0 ```\. For a value of zero or negative one, ``` -1 ``` will be returned\.  
   
-#### <code>glm.<code>**findMSB**(**value**: *vecN*) -\> *vecN*</code></code>  
+#### <code>glm.<code>**findMSB**(**value**: *vecN*) -\> *ivecN*</code></code>  
 &emsp;&emsp;Returns the bit number of the least significant bit set to ``` 1 ``` in the binary representation  
 &emsp;&emsp;of ``` value ```\. If ``` value ``` is zero, ``` -1 ``` will be returned\.  
   
 ### imulExtended\(\) function  
+#### <code>glm.<code>**imulExtended**(**x**: *int*, **y**: *int*) -\> *(msb: int, lsb: int)*</code></code>  
+&emsp;&emsp;Multiplies 32\-bit integers ``` x ``` and ``` y ```, producing a 64\-bit result\. The 32 least\-significant  
+&emsp;&emsp;bits are returned in ``` lsb ```\. The 32 most\-significant bits are returned in ``` msb ```\.  
+  
 #### <code>glm.<code>**imulExtended**(**x**: *ivecN*, **y**: *ivecN*, **msb**: *ivecN*, **lsb**: *ivecN*) -\> *ivecN*</code></code>  
 &emsp;&emsp;Multiplies 32\-bit integers ``` x ``` and ``` y ```, producing a 64\-bit result\. The 32 least\-significant  
 &emsp;&emsp;bits are returned in ``` lsb ```\. The 32 most\-significant bits are returned in ``` msb ```\.  
   
 ### uaddCarry\(\) function  
+#### <code>glm.<code>**uaddCarry**(**x**: *int*, **y**: *int*) -\> *(result: int, carry: int)*</code></code>  
+&emsp;&emsp;Adds 32\-bit unsigned integer ``` x ``` and ``` y ```, returning the ``` sum ``` modulo ``` pow(2, 32) ```\. The value carry  
+&emsp;&emsp;is set to ``` 0 ``` if the ``` sum ``` was less than ``` pow(2, 32) ```, or to ``` 1 ``` otherwise\.  
+  
 #### <code>glm.<code>**uaddCarry**(**x**: *uvecN*, **y**: *uvecN*, **carry**: *uvecN*) -\> *uvecN*</code></code>  
 &emsp;&emsp;Adds 32\-bit unsigned integer ``` x ``` and ``` y ```, returning the ``` sum ``` modulo ``` pow(2, 32) ```\. The value carry  
 &emsp;&emsp;is set to ``` 0 ``` if the ``` sum ``` was less than ``` pow(2, 32) ```, or to ``` 1 ``` otherwise\.  
   
 ### umulExtended\(\) function  
+#### <code>glm.<code>**umulExtended**(**x**: *int*, **y**: *int*) -\> *(msb: int, lsb: int)*</code></code>  
+&emsp;&emsp;Multiplies 32\-bit integers ``` x ``` and ``` y ```, producing a 64\-bit result\. The 32 least\-significant  
+&emsp;&emsp;bits are returned in ``` lsb ```\. The 32 most\-significant bits are returned in ``` msb ```\.  
+  
 #### <code>glm.<code>**umulExtended**(**x**: *uvecN*, **y**: *uvecN*, **msb**: *uvecN*, **lsb**: *uvecN*) -\> *uvecN*</code></code>  
 &emsp;&emsp;Multiplies 32\-bit integers ``` x ``` and ``` y ```, producing a 64\-bit result\. The 32 least\-significant  
 &emsp;&emsp;bits are returned in ``` lsb ```\. The 32 most\-significant bits are returned in ``` msb ```\.  
   
 ### usubBorrow\(\) function  
+#### <code>glm.<code>**usubBorrow**(**x**: *int*, **y**: *int*) -\> *(result: int, borrow: int)*</code></code>  
+&emsp;&emsp;Subtracts the 32\-bit unsigned integer ``` y ``` from ``` x ```, returning the difference if non\-negative,  
+&emsp;&emsp;or ``` pow(2, 32) ``` plus the difference otherwise\. The value borrow is set to ``` 0 ``` if ``` x >= y ```, or to  
+&emsp;&emsp;``` 1 ``` otherwise\.  
+  
 #### <code>glm.<code>**usubBorrow**(**x**: *uvecN*, **y**: *uvecN*, **borrow**: *uvecN*) -\> *uvecN*</code></code>  
 &emsp;&emsp;Subtracts the 32\-bit unsigned integer ``` y ``` from ``` x ```, returning the difference if non\-negative,  
 &emsp;&emsp;or ``` pow(2, 32) ``` plus the difference otherwise\. The value borrow is set to ``` 0 ``` if ``` x >= y ```, or to  

--- a/wiki/function-reference/detail/func_integer.sb
+++ b/wiki/function-reference/detail/func_integer.sb
@@ -19,38 +19,43 @@ It contains GLSL functions on integer types.
 \raw\#### <code>glm.<code>**bitCount**(**v**: *int*) -\\> *int*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns the number of bits set to \code\1\code\ in the binary representation of \code\value\code\.
 
-\raw\#### <code>glm.<code>**bitCount**(**v**: *ivecN*) -\\> *ivecN*</code></code>\raw\
+\raw\#### <code>glm.<code>**bitCount**(**v**: *vecN*) -\\> *ivecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\For every component \code\c\code\ of \code\v\code\:
 \raw\&emsp;&emsp;\raw\Returns the number of bits set to \code\1\code\ in the binary representation of \code\c\code\.
 
 \h3\bitfieldExtract() function\h3\
-\raw\#### <code>glm.<code>**bitfieldExtract**(**value**: *int*, **offset**: *int*, **bits**: *int*) -\\> *int*</code></code>\raw\
+\raw\#### <code>glm.<code>**bitfieldExtract**(**value**: *ctypes*, **offset**: *int*, **bits**: *int*) -\\> *int*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Extracts bits \code\[offset, offset + bits - 1]\code\ from value, returning them in the least
 \raw\&emsp;&emsp;\raw\significant bits of the result. For unsigned data types, the most significant bits of the
 \raw\&emsp;&emsp;\raw\result will be set to zero. For signed data types, the most significant bits will be set to
 \raw\&emsp;&emsp;\raw\the value of bit \code\offset + base - 1\code\. If \code\bits\code\ is zero, the result will be zero. The result
 \raw\&emsp;&emsp;\raw\will be undefined if \code\offset\code\ or \code\bits\code\ is negative, or if the sum of \code\offset\code\ and \code\bits\code\ is
 \raw\&emsp;&emsp;\raw\greater than the number of bits used to store the operand.
+\raw\&emsp;&emsp;\raw\You can use \code\int32\code\, \code\uint32\code\, \code\int64\code\ or \code\uint64\code\ types to specify the number of bits and the
+\raw\&emsp;&emsp;\raw\sign.
 
 \raw\#### <code>glm.<code>**bitfieldExtract**(**value**: *vecN*, **offset**: *int*, **bits**: *int*) -\\> *vecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns \code\bitfieldExtract(c, offset, bits)\code\ for every component \code\c\code\ of \code\value\code\.
 
 \h3\bitfieldInsert() function\h3\
-\raw\#### <code>glm.<code>**bitfieldInsert**(**base**: *int*, **insert**: *int*, **offset**: *int*, **bits**: *int*) -\\> *int*</code></code>\raw\
+\raw\#### <code>glm.<code>**bitfieldInsert**(**base**: *ctypes*, **insert**: *ctypes*, **offset**: *int*, **bits**: *int*) -\\> *int*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns the insertion the bits least-significant bits of insert into base. The result will
 \raw\&emsp;&emsp;\raw\have \code\bits[offset, offset + bits - 1]\code\ taken from \code\bits[0, bits - 1]\code\ of \code\insert\code\, and all other
 \raw\&emsp;&emsp;\raw\bits taken directly from the corresponding bits of \code\base\code\. If \code\bits\code\ is zero, the result will
 \raw\&emsp;&emsp;\raw\simply be \code\base\code\. The result will be undefined if \code\offset\code\ or \code\bits\code\ is negative, or if the sum of
 \raw\&emsp;&emsp;\raw\\code\offset\code\ and \code\bits\code\ is greater than the number of bits used to store the operand.
+\raw\&emsp;&emsp;\raw\You can use \code\int32\code\, \code\uint32\code\, \code\int64\code\ or \code\uint64\code\ types to specify the number of bits and the
+\raw\&emsp;&emsp;\raw\sign.
 
 \raw\#### <code>glm.<code>**bitfieldInsert**(**base**: *vecN*, **insert**: *vecN*, **offset**: *int*, **bits**: *int*) -\\> *vecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns \code\bitfieldInsert(base[i], insert[i], offset, bits)\code\ for every index \code\i\code\.
 
 \h3\bitfieldReverse() function\h3\
-\raw\#### <code>glm.<code>**bitfieldReverse**(**value**: *int*) -\\> *int*</code></code>\raw\
+\raw\#### <code>glm.<code>**bitfieldReverse**(**value**: *ctypes*) -\\> *int*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns the reversal of the bits of \code\value\code\. The bit numbered \code\n\code\ of the result will be taken
 \raw\&emsp;&emsp;\raw\from \code\bit(bits - 1) - n\code\ of \code\value\code\, where \code\bits\code\ is the total number of bits used to represent
-\raw\&emsp;&emsp;\raw\\code\value\code\.
+\raw\&emsp;&emsp;\raw\\code\value\code\. You can use \code\int32\code\, \code\uint32\code\, \code\int64\code\ or \code\uint64\code\ types to specify the number of bits
+\raw\&emsp;&emsp;\raw\and the sign.
 
 \raw\#### <code>glm.<code>**bitfieldReverse**(**value**: *vecN*) -\\> *vecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns the reversal of the bits of \code\value\code\. The bit numbered \code\n\code\ of the result will be taken
@@ -62,7 +67,7 @@ It contains GLSL functions on integer types.
 \raw\&emsp;&emsp;\raw\Returns the bit number of the least significant bit set to \code\1\code\ in the binary representation
 \raw\&emsp;&emsp;\raw\of \code\value\code\. If \code\value\code\ is zero, \code\-1\code\ will be returned.
 
-\raw\#### <code>glm.<code>**findLSB**(**value**: *vecN*) -\\> *vecN*</code></code>\raw\
+\raw\#### <code>glm.<code>**findLSB**(**value**: *vecN*) -\\> *ivecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns the bit number of the least significant bit set to \code\1\code\ in the binary representation
 \raw\&emsp;&emsp;\raw\of \code\value\code\. If \code\value\code\ is zero, \code\-1\code\ will be returned.
 
@@ -73,26 +78,43 @@ It contains GLSL functions on integer types.
 \raw\&emsp;&emsp;\raw\\code\1\code\. For negative integers, the result will be the bit number of the most significant bit set
 \raw\&emsp;&emsp;\raw\to \code\0\code\. For a value of zero or negative one, \code\-1\code\ will be returned.
 
-\raw\#### <code>glm.<code>**findMSB**(**value**: *vecN*) -\\> *vecN*</code></code>\raw\
+\raw\#### <code>glm.<code>**findMSB**(**value**: *vecN*) -\\> *ivecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Returns the bit number of the least significant bit set to \code\1\code\ in the binary representation
 \raw\&emsp;&emsp;\raw\of \code\value\code\. If \code\value\code\ is zero, \code\-1\code\ will be returned.
 
 \h3\imulExtended() function\h3\
+\raw\#### <code>glm.<code>**imulExtended**(**x**: *int*, **y**: *int*) -\\> *(msb: int, lsb: int)*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Multiplies 32-bit integers \code\x\code\ and \code\y\code\, producing a 64-bit result. The 32 least-significant
+\raw\&emsp;&emsp;\raw\bits are returned in \code\lsb\code\. The 32 most-significant bits are returned in \code\msb\code\.
+
 \raw\#### <code>glm.<code>**imulExtended**(**x**: *ivecN*, **y**: *ivecN*, **msb**: *ivecN*, **lsb**: *ivecN*) -\\> *ivecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Multiplies 32-bit integers \code\x\code\ and \code\y\code\, producing a 64-bit result. The 32 least-significant
 \raw\&emsp;&emsp;\raw\bits are returned in \code\lsb\code\. The 32 most-significant bits are returned in \code\msb\code\.
 
 \h3\uaddCarry() function\h3\
+\raw\#### <code>glm.<code>**uaddCarry**(**x**: *int*, **y**: *int*) -\\> *(result: int, carry: int)*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Adds 32-bit unsigned integer \code\x\code\ and \code\y\code\, returning the \code\sum\code\ modulo \code\pow(2, 32)\code\. The value carry
+\raw\&emsp;&emsp;\raw\is set to \code\0\code\ if the \code\sum\code\ was less than \code\pow(2, 32)\code\, or to \code\1\code\ otherwise.
+
 \raw\#### <code>glm.<code>**uaddCarry**(**x**: *uvecN*, **y**: *uvecN*, **carry**: *uvecN*) -\\> *uvecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Adds 32-bit unsigned integer \code\x\code\ and \code\y\code\, returning the \code\sum\code\ modulo \code\pow(2, 32)\code\. The value carry
 \raw\&emsp;&emsp;\raw\is set to \code\0\code\ if the \code\sum\code\ was less than \code\pow(2, 32)\code\, or to \code\1\code\ otherwise.
 
 \h3\umulExtended() function\h3\
+\raw\#### <code>glm.<code>**umulExtended**(**x**: *int*, **y**: *int*) -\\> *(msb: int, lsb: int)*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Multiplies 32-bit integers \code\x\code\ and \code\y\code\, producing a 64-bit result. The 32 least-significant
+\raw\&emsp;&emsp;\raw\bits are returned in \code\lsb\code\. The 32 most-significant bits are returned in \code\msb\code\.
+
 \raw\#### <code>glm.<code>**umulExtended**(**x**: *uvecN*, **y**: *uvecN*, **msb**: *uvecN*, **lsb**: *uvecN*) -\\> *uvecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Multiplies 32-bit integers \code\x\code\ and \code\y\code\, producing a 64-bit result. The 32 least-significant
 \raw\&emsp;&emsp;\raw\bits are returned in \code\lsb\code\. The 32 most-significant bits are returned in \code\msb\code\.
 
 \h3\usubBorrow() function\h3\
+\raw\#### <code>glm.<code>**usubBorrow**(**x**: *int*, **y**: *int*) -\\> *(result: int, borrow: int)*</code></code>\raw\
+\raw\&emsp;&emsp;\raw\Subtracts the 32-bit unsigned integer \code\y\code\ from \code\x\code\, returning the difference if non-negative,
+\raw\&emsp;&emsp;\raw\or \code\pow(2, 32)\code\ plus the difference otherwise. The value borrow is set to \code\0\code\ if \code\x >= y\code\, or to
+\raw\&emsp;&emsp;\raw\\code\1\code\ otherwise.
+
 \raw\#### <code>glm.<code>**usubBorrow**(**x**: *uvecN*, **y**: *uvecN*, **borrow**: *uvecN*) -\\> *uvecN*</code></code>\raw\
 \raw\&emsp;&emsp;\raw\Subtracts the 32-bit unsigned integer \code\y\code\ from \code\x\code\, returning the difference if non-negative,
 \raw\&emsp;&emsp;\raw\or \code\pow(2, 32)\code\ plus the difference otherwise. The value borrow is set to \code\0\code\ if \code\x >= y\code\, or to


### PR DESCRIPTION
+ Fixed `sign`, `uaddCarry`, `usubBorrow`, `umulExtended`, `imulExtended` not accepting integer inputs
+ Changed `bitfieldExtract`, `bitfieldInsert`, `bitfieldReverse` to require `ctypes` types to determine the int type to use
+ Fixed `bitCount`, `findLSB`, `findMSB` not using the optimal int type
+ Fixed `equal` 
+ Fixed integer overflows causing a crash (now raising a warning instead)
+ Deprecated `frexp` warning
+ Added tests from glm