### PR TITLE
Make array generic.

### DIFF
--- a/PyGLM/types/glmArray/forward_declarations.h
+++ b/PyGLM/types/glmArray/forward_declarations.h
@@ -176,6 +176,10 @@ PyDoc_STRVAR(glmArray_setstate_docstr,
 
 static PyObject* glmArray_setstate(glmArray* self, PyObject* state);
 
+PyDoc_STRVAR(glmArray_class_getitem_docstr,
+	"See PEP 585"
+);
+
 PyDoc_STRVAR(glmArray_filter_docstr,
 	"filter(func: callable) -> array\n"
 	"	Filters this array with the given funtion and returns the resulting array.\n"

--- a/PyGLM/types/glmArray/glmArray.h
+++ b/PyGLM/types/glmArray/glmArray.h
@@ -28,6 +28,9 @@ static PyMethodDef glmArray_methods[] = {
 	{ "__deepcopy__",	(PyCFunction)generic_deepcopy,			METH_O,						generic_deepcopy_docstr },
 	{ "__getstate__",	(PyCFunction)glmArray_getstate,			METH_NOARGS,				glmArray_getstate_docstr },
 	{ "__setstate__",	(PyCFunction)glmArray_setstate,			METH_O,						glmArray_setstate_docstr },
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
+    { "__class_getitem__", Py_GenericAlias,                     METH_O | METH_CLASS,        glmArray_class_getitem_docstr },
+#endif
 	{ "to_bytes",		(PyCFunction)glmArray_to_bytes,			METH_NOARGS,				glmArray_to_bytes_docstr },
 	{ "from_bytes",		(PyCFunction)glmArray_from_bytes,		METH_VARARGS | METH_STATIC, glmArray_from_bytes_docstr },
 	{ "reinterpret_cast",(PyCFunction)glmArray_reinterpret_cast,METH_O,						glmArray_reinterpret_cast_docstr },


### PR DESCRIPTION
I've created type stubs for pyglm (https://github.com/esoma/pyglm-typing). There is a runtime wart with them however, `glm.array` is not generic (as in `typing.Generic`) and my typing stubs are. It works for the most part where annotations are only statically assessed, but some static typing is inevitably also runtime, for example in the case of type aliases:
```python
MyVectorArray = array[vec2] | array[vec3] | array[vec4]
```
This will fail at runtime since the `array` class doesn't follow the generic typing protocol. 

Luckily this is fairly easy to add in 3.9+: https://docs.python.org/3/c-api/typehints.html

So I've gone ahead and done that in this PR with the understanding that this isn't perfect. PyGLM of course doesn't officially support typing so this is kind of hacky (and btw, if you'd like to support typing I'd be happy to discuss merging the stubs into this repo). Also it's only 3.9+, it's possible to support this in various ways for all of PyGLM's supported versions (3.7+ would require a custom implementation of `Py_GenericAlias` and 3.5+ would require a metaclass -- those seem a much larger lift). 