### PR TITLE
fixed memory use after free in vec_getattr and vec_setattr (#181)

### DIFF
--- a/PyGLM/internal_functions/helper_macros.h
+++ b/PyGLM/internal_functions/helper_macros.h
@@ -39,10 +39,3 @@
 
 #define PyGLM_INCREF(ob) (Py_INCREF(ob), ob)
 #define PyGLM_DECREF(ob) (Py_DECREF(ob), ob)
-
-static char* PyGLM_String_AsString(PyObject* name) {
-	PyObject* asciiString = PyUnicode_AsASCIIString(name);
-	char* out = PyBytes_AsString(asciiString);
-	Py_DECREF(asciiString);
-	return out;
-}

--- a/PyGLM/type_methods/mvec.h
+++ b/PyGLM/type_methods/mvec.h
@@ -1148,23 +1148,31 @@ static T& unswizzle2_mvec(mvec<4, T> * self, char c, bool& success) {
 
 template<int L, typename T>
 static PyObject * mvec_getattr(PyObject * obj, PyObject * name) {
-	char * name_as_ccp = PyGLM_String_AsString(name);
-	size_t len = strlen(name_as_ccp);
-
-	if (len >= 4 && name_as_ccp[0] == '_' && name_as_ccp[1] == '_' && name_as_ccp[len - 1] == '_' && name_as_ccp[len - 2] == '_') {
-		return PyObject_GenericGetAttr(obj, name);
+	ssize_t len;
+	char* name_as_ccp;
+	PyObject* asciiString = PyUnicode_AsASCIIString(name);
+	if (asciiString == NULL)
+		return NULL;
+	if (PyBytes_AsStringAndSize(asciiString, &name_as_ccp, &len) != 0) {
+		Py_DECREF(asciiString);
+		return NULL;
 	}
-	if (len == 1) {
+	
+	PyObject * result = NULL;
+	if (len >= 4 && name_as_ccp[0] == '_' && name_as_ccp[1] == '_' && name_as_ccp[len - 1] == '_' && name_as_ccp[len - 2] == '_') {
+		result = PyObject_GenericGetAttr(obj, name);
+	}
+	else if (len == 1) {
 		T x;
 		if (unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[0], x)) {
-			return PyGLM_PyObject_FromNumber<T>((T)x);
+			result = PyGLM_PyObject_FromNumber<T>((T)x);
 		}
 	}
 	else if (len == 2) {
 		T x;
 		T y;
 		if (unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[0], x) && unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[1], y)) {
-			return pack_vec<2, T>(glm::vec<2, T>(x, y));
+			result = pack_vec<2, T>(glm::vec<2, T>(x, y));
 		}
 	}
 	else if (len == 3) {
@@ -1172,7 +1180,7 @@ static PyObject * mvec_getattr(PyObject * obj, PyObject * name) {
 		T y;
 		T z;
 		if (unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[0], x) && unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[1], y) && unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[2], z)) {
-			return pack_vec<3, T>(glm::vec<3, T>(x, y, z));
+			result = pack_vec<3, T>(glm::vec<3, T>(x, y, z));
 		}
 	}
 	else if (len == 4) {
@@ -1181,10 +1189,12 @@ static PyObject * mvec_getattr(PyObject * obj, PyObject * name) {
 		T z;
 		T w;
 		if (unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[0], x) && unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[1], y) && unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[2], z) && unswizzle_mvec((mvec<L, T> *)obj, name_as_ccp[3], w)) {
-			return pack_vec<4, T>(glm::vec<4, T>(x, y, z, w));
+			result = pack_vec<4, T>(glm::vec<4, T>(x, y, z, w));
 		}
 	}
-	return PyObject_GenericGetAttr(obj, name);
+	Py_DECREF(asciiString);
+	if (result == NULL)   return PyObject_GenericGetAttr(obj, name);
+	else                  return result;
 }
 
 template<int L, typename T>
@@ -1194,17 +1204,17 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 		return -1;
 	}
 
-	char * name_as_ccp = PyGLM_String_AsString(name);
+	PyObject* asciiString = PyUnicode_AsASCIIString(name);
+	char* name_as_ccp = PyBytes_AsString(asciiString);
 	size_t len = strlen(name_as_ccp);
 
+	bool success = true;
 	if (PyGLM_Number_Check(value)) {
 		T v = PyGLM_Number_FromPyObject<T>(value);
-		bool success = true;
 		if (len == 1) {
 			T& x = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[0], success);
 			if (success) {
 				x = v;
-				return 0;
 			}
 		}
 		else if (len == 2) {
@@ -1213,7 +1223,6 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 			if (success) {
 				x = v;
 				y = v;
-				return 0;
 			}
 		}
 		else if (len == 3) {
@@ -1224,7 +1233,6 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				x = v;
 				y = v;
 				z = v;
-				return 0;
 			}
 		}
 		else if (len == 4) {
@@ -1237,7 +1245,6 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				y = v;
 				z = v;
 				w = v;
-				return 0;
 			}
 		}
 	}
@@ -1245,27 +1252,22 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 		PyGLM_PTI_Init0(value, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_PTI_GetDT(T));
 		if (len == 1 && PyGLM_Vec_PTI_Check0(1, T, value)) {
 			glm::vec<1, T> v = PyGLM_Vec_PTI_Get0(1, T, value);
-			bool success = true;
 			T& x = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[0], success);
 			if (success) {
 				x = v.x;
-				return 0;
 			}
 		}
 		else if (len == 2 && PyGLM_Vec_PTI_Check0(2, T, value)) {
 			glm::vec<2, T> v = PyGLM_Vec_PTI_Get0(2, T, value);
-			bool success = true;
 			T& x = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[0], success);
 			T& y = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[1], success);
 			if (success) {
 				x = v.x;
 				y = v.y;
-				return 0;
 			}
 		}
 		else if (len == 3 && PyGLM_Vec_PTI_Check0(3, T, value)) {
 			glm::vec<3, T> v = PyGLM_Vec_PTI_Get0(3, T, value);
-			bool success = true;
 			T& x = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[0], success);
 			T& y = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[1], success);
 			T& z = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[2], success);
@@ -1273,12 +1275,10 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				x = v.x;
 				y = v.y;
 				z = v.z;
-				return 0;
 			}
 		}
 		else if (len == 4 && PyGLM_Vec_PTI_Check0(4, T, value)) {
 			glm::vec<4, T> v = PyGLM_Vec_PTI_Get0(4, T, value);
-			bool success = true;
 			T& x = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[0], success);
 			T& y = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[1], success);
 			T& z = unswizzle2_mvec((mvec<L, T>*)obj, name_as_ccp[2], success);
@@ -1288,12 +1288,13 @@ static int mvec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				y = v.y;
 				z = v.z;
 				w = v.w;
-				return 0;
 			}
 		}
 	}
 	
-	return PyObject_GenericSetAttr(obj, name, value);
+	Py_DECREF(asciiString);
+	if (success)    return 0;
+	else            return PyObject_GenericSetAttr(obj, name, value);
 }
 
 // iterator

--- a/PyGLM/type_methods/mvec.h
+++ b/PyGLM/type_methods/mvec.h
@@ -1148,7 +1148,7 @@ static T& unswizzle2_mvec(mvec<4, T> * self, char c, bool& success) {
 
 template<int L, typename T>
 static PyObject * mvec_getattr(PyObject * obj, PyObject * name) {
-	ssize_t len;
+	Py_ssize_t len;
 	char* name_as_ccp;
 	PyObject* asciiString = PyUnicode_AsASCIIString(name);
 	if (asciiString == NULL)

--- a/PyGLM/type_methods/vec.h
+++ b/PyGLM/type_methods/vec.h
@@ -1799,7 +1799,7 @@ static T& unswizzle2_vec(vec<4, T> * self, char c, bool& success) {
 
 template<int L, typename T>
 static PyObject * vec_getattr(PyObject * obj, PyObject * name) {
-	ssize_t len;
+	Py_ssize_t len;
 	char* name_as_ccp;
 	PyObject* asciiString = PyUnicode_AsASCIIString(name);
 	if (asciiString == NULL)

--- a/PyGLM/type_methods/vec.h
+++ b/PyGLM/type_methods/vec.h
@@ -1799,23 +1799,31 @@ static T& unswizzle2_vec(vec<4, T> * self, char c, bool& success) {
 
 template<int L, typename T>
 static PyObject * vec_getattr(PyObject * obj, PyObject * name) {
-	char * name_as_ccp = PyGLM_String_AsString(name);
-	size_t len = strlen(name_as_ccp);
-
-	if (len >= 4 && name_as_ccp[0] == '_' && name_as_ccp[1] == '_' && name_as_ccp[len - 1] == '_' && name_as_ccp[len - 2] == '_') {
-		return PyObject_GenericGetAttr(obj, name);
+	ssize_t len;
+	char* name_as_ccp;
+	PyObject* asciiString = PyUnicode_AsASCIIString(name);
+	if (asciiString == NULL)
+		return NULL;
+	if (PyBytes_AsStringAndSize(asciiString, &name_as_ccp, &len) != 0) {
+		Py_DECREF(asciiString);
+		return NULL;
 	}
-	if (len == 1) {
+
+	PyObject * result = NULL;
+	if (len >= 4 && name_as_ccp[0] == '_' && name_as_ccp[1] == '_' && name_as_ccp[len - 1] == '_' && name_as_ccp[len - 2] == '_') {
+		result = PyObject_GenericGetAttr(obj, name);
+	}
+	else if (len == 1) {
 		T x;
 		if (unswizzle_vec((vec<L, T> *)obj, name_as_ccp[0], x)) {
-			return PyGLM_PyObject_FromNumber<T>((T)x);
+			result = PyGLM_PyObject_FromNumber<T>((T)x);
 		}
 	}
 	else if (len == 2) {
 		T x;
 		T y;
 		if (unswizzle_vec((vec<L, T> *)obj, name_as_ccp[0], x) && unswizzle_vec((vec<L, T> *)obj, name_as_ccp[1], y)) {
-			return pack_vec<2, T>(glm::vec<2, T>(x, y));
+			result = pack_vec<2, T>(glm::vec<2, T>(x, y));
 		}
 	}
 	else if (len == 3) {
@@ -1823,7 +1831,7 @@ static PyObject * vec_getattr(PyObject * obj, PyObject * name) {
 		T y;
 		T z;
 		if (unswizzle_vec((vec<L, T> *)obj, name_as_ccp[0], x) && unswizzle_vec((vec<L, T> *)obj, name_as_ccp[1], y) && unswizzle_vec((vec<L, T> *)obj, name_as_ccp[2], z)) {
-			return pack_vec<3, T>(glm::vec<3, T>(x, y, z));
+			result = pack_vec<3, T>(glm::vec<3, T>(x, y, z));
 		}
 	}
 	else if (len == 4) {
@@ -1832,10 +1840,12 @@ static PyObject * vec_getattr(PyObject * obj, PyObject * name) {
 		T z;
 		T w;
 		if (unswizzle_vec((vec<L, T> *)obj, name_as_ccp[0], x) && unswizzle_vec((vec<L, T> *)obj, name_as_ccp[1], y) && unswizzle_vec((vec<L, T> *)obj, name_as_ccp[2], z) && unswizzle_vec((vec<L, T> *)obj, name_as_ccp[3], w)) {
-			return pack_vec<4, T>(glm::vec<4, T>(x, y, z, w));
+			result = pack_vec<4, T>(glm::vec<4, T>(x, y, z, w));
 		}
 	}
-	return PyObject_GenericGetAttr(obj, name);
+	Py_DECREF(asciiString);
+	if (result == NULL)    return PyObject_GenericGetAttr(obj, name);
+	else                   return result;
 }
 
 template<int L, typename T>
@@ -1846,21 +1856,17 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 		return -1;
 	}
 
-	char * name_as_ccp = PyGLM_String_AsString(name);
+	PyObject* asciiString = PyUnicode_AsASCIIString(name);
+	char* name_as_ccp = PyBytes_AsString(asciiString);
 	size_t len = strlen(name_as_ccp);
 
-	//if (len >= 4 && name_as_ccp[0] == '_' && name_as_ccp[1] == '_' && name_as_ccp[len - 1] == '_' && name_as_ccp[len - 2] == '_') {
-	//	return PyObject_GenericGetAttr(obj, name);
-	//}
-
+	bool success = true;
 	if (PyGLM_Number_Check(value)) {
 		T v = PyGLM_Number_FromPyObject<T>(value);
-		bool success = true;
 		if (len == 1) {
 			T& x = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[0], success);
 			if (success) {
 				x = v;
-				return 0;
 			}
 		}
 		else if (len == 2) {
@@ -1869,7 +1875,6 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 			if (success) {
 				x = v;
 				y = v;
-				return 0;
 			}
 		}
 		else if (len == 3) {
@@ -1880,7 +1885,6 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				x = v;
 				y = v;
 				z = v;
-				return 0;
 			}
 		}
 		else if (len == 4) {
@@ -1893,7 +1897,6 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				y = v;
 				z = v;
 				w = v;
-				return 0;
 			}
 		}
 	}
@@ -1901,27 +1904,22 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 		PyGLM_PTI_Init0(value, PyGLM_T_VEC | PyGLM_SHAPE_ALL | PyGLM_PTI_GetDT(T));
 		if (len == 1 && PyGLM_Vec_PTI_Check0(1, T, value)) {
 			glm::vec<1, T> v = PyGLM_Vec_PTI_Get0(1, T, value);
-			bool success = true;
 			T& x = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[0], success);
 			if (success) {
 				x = v.x;
-				return 0;
 			}
 		}
 		else if (len == 2 && PyGLM_Vec_PTI_Check0(2, T, value)) {
 			glm::vec<2, T> v = PyGLM_Vec_PTI_Get0(2, T, value);
-			bool success = true;
 			T& x = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[0], success);
 			T& y = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[1], success);
 			if (success) {
 				x = v.x;
 				y = v.y;
-				return 0;
 			}
 		}
 		else if (len == 3 && PyGLM_Vec_PTI_Check0(3, T, value)) {
 			glm::vec<3, T> v = PyGLM_Vec_PTI_Get0(3, T, value);
-			bool success = true;
 			T& x = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[0], success);
 			T& y = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[1], success);
 			T& z = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[2], success);
@@ -1929,12 +1927,10 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				x = v.x;
 				y = v.y;
 				z = v.z;
-				return 0;
 			}
 		}
 		else if (len == 4 && PyGLM_Vec_PTI_Check0(4, T, value)) {
 			glm::vec<4, T> v = PyGLM_Vec_PTI_Get0(4, T, value);
-			bool success = true;
 			T& x = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[0], success);
 			T& y = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[1], success);
 			T& z = unswizzle2_vec((vec<L, T>*)obj, name_as_ccp[2], success);
@@ -1944,11 +1940,12 @@ static int vec_setattr(PyObject * obj, PyObject * name, PyObject* value) {
 				y = v.y;
 				z = v.z;
 				w = v.w;
-				return 0;
 			}
 		}
 	}
-	return PyObject_GenericSetAttr(obj, name, value);
+	Py_DECREF(asciiString);
+	if (success)    return 0;
+	else            return PyObject_GenericSetAttr(obj, name, value);
 }
 
 // iterator


### PR DESCRIPTION
This is a small patch to fix issue #181 :)
I just expanded macro `PyGLM_String_AsString` where it was used, and released the temporary `bytes` object after all checks are done.
It works fine on my side (linux x86_64, python 3.8) and fixes the issue