### PR TITLE
fix broken sdist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = glm
 	url = https://github.com/Zuzu-Typ/glm
 	branch = PyGLM
-[submodule "pyglm-typing"]
-	path = pyglm-typing
-	url = https://github.com/esoma/pyglm-typing

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages, Extension
 from codecs import open
 from os import path
 
-import re, os, shutil
+import re
 
 module1 = Extension('glm',
                     sources = ['PyGLM.cpp'], include_dirs=["glm/"], extra_compile_args=['-std=c++11'])

--- a/setup.py
+++ b/setup.py
@@ -29,16 +29,6 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
     long_description = long_description.replace("\r", "")
 
-# Update glm-stubs
-shutil.copy2("pyglm-typing/src/glm_typing/__init__.py", "glm-stubs/glm_typing.py")
-shutil.copy2("pyglm-typing/src/glm-stubs/__init__.py", "glm-stubs")
-with open(path.join(here, "pyglm-typing/src/glm-stubs/__init__.pyi"), encoding="utf-8") as f:
-    typing_data = f.read()
-
-    out_file = open(path.join(here, "glm-stubs/__init__.pyi"), "w", encoding="utf-8")
-    out_file.write(typing_data.replace("import glm_typing", "from . import glm_typing"))
-    out_file.close()
-    
 
 setup(
     name='PyGLM',


### PR DESCRIPTION
The sdist is broken because the setup.py cannot be called to get the package metadata because there is a copy operation at the root level.

When executing `pip download PyGLM==2.7.0 --no-binary=:all:` the downloaded source is not enough to get all the information about your package/module (for historical reasons, wheels do this better).

pip runs the setup.py to extract the metadata. This is not possible due to the copy operations in the root.
Insead of including those files in the MANIFEST.in as a hotfix. I removed the entire submodule and the copy operation from the setup.py as it would be correct.

Fixing it by other means, even adding the copy as a side effect for the build would just cause additional troubles.
Please consider merging this and maybe adding an acknowledgement to the author of the other repo.
stubs should clearly not be a submodule.

PS: glm should, that is 100% correct, submodules are great.
