### PR TITLE
Python3.13 support

### DIFF
--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
     
 env:
   CIBW_BUILD: cp3*
-  CIBW_SKIP: cp36-* cp37-*
+  CIBW_SKIP: cp36-* cp37-* cp38-*
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest {project}/test/PyGLM_test.py -v
 
@@ -24,13 +24,13 @@ jobs:
         with:
             submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -54,13 +54,13 @@ jobs:
         with:
             submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -97,13 +97,13 @@ jobs:
         if: ${{ matrix.arch != 'x86_64' && matrix.arch != 'i686' }}
         uses: docker/setup-qemu-action@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -136,13 +136,13 @@ jobs:
         if: ${{ matrix.arch != 'x86_64' && matrix.arch != 'i686' }}
         uses: docker/setup-qemu-action@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -159,10 +159,10 @@ jobs:
         with:
             submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           
       - name: Install build
         run: pip install build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
     
 env:
   CIBW_BUILD: cp3*
-  CIBW_SKIP: cp36-* cp37-*
+  CIBW_SKIP: cp36-* cp37-* cp38-*
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest {project}/test/PyGLM_test.py -v
 
@@ -27,13 +27,13 @@ jobs:
         with:
             submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -57,13 +57,13 @@ jobs:
         with:
             submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -100,13 +100,13 @@ jobs:
         if: ${{ matrix.arch != 'x86_64' && matrix.arch != 'i686' }}
         uses: docker/setup-qemu-action@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -139,13 +139,13 @@ jobs:
         if: ${{ matrix.arch != 'x86_64' && matrix.arch != 'i686' }}
         uses: docker/setup-qemu-action@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.21.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -162,10 +162,10 @@ jobs:
         with:
             submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install build
         run: pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Adds support for Python 3.13.
Deprecates support for Python 3.8.


Depends on https://github.com/actions/python-versions/pull/312