### PR TITLE
Updated deploy action to newer musllinux and arm runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -64,7 +64,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         distro: [manylinux2014, manylinux_2_28]
-        arch: [x86_64, aarch64, s390x]
+        arch: [x86_64, s390x]
         include:
           - distro: manylinux2014
             arch: i686
@@ -88,7 +88,6 @@ jobs:
     env:
       CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.distro }}
       CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.distro }}
-      CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.distro }}
       CIBW_MANYLINUX_S390X_IMAGE: ${{ matrix.distro }}
       CIBW_BUILD: cp3*-manylinux*
       CIBW_ARCHS: ${{matrix.arch}}
@@ -108,7 +107,46 @@ jobs:
           python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==2.22.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.distro }}-${{matrix.arch}}
+          path: ./wheelhouse/*.whl
+
+  build_wheels_manylinux_arm:
+    name: Build wheels on ${{ matrix.distro }} for ${{ matrix.arch }}
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        distro: [manylinux2014, manylinux_2_28]
+        arch: [aarch64]
+        #include:
+        #  - distro: manylinux_2_31
+        #    arch: armv7l
+            
+        
+    env:
+      CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.distro }}
+      CIBW_MANYLINUX_ARMV7L_IMAGE: ${{ matrix.distro }}
+      CIBW_BUILD: cp3*-manylinux*
+      CIBW_ARCHS: ${{matrix.arch}}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -119,17 +157,16 @@ jobs:
           path: ./wheelhouse/*.whl
           
   build_wheels_musllinux:
-    name: Build wheels on musllinux_1_1 for ${{ matrix.arch }}
+    name: Build wheels on musllinux_1_2 for ${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [x86_64, i686, aarch64, s390x]
+        arch: [x86_64, i686, s390x]
         
     env:
-      CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
-      CIBW_MUSLLINUX_I686_IMAGE: musllinux_1_1
-      CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_1
-      CIBW_MUSLLINUX_S390X_IMAGE: musllinux_1_1
+      CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_I686_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_S390X_IMAGE: musllinux_1_2
       CIBW_BUILD: cp3*-musllinux*
       CIBW_ARCHS: ${{matrix.arch}}
 
@@ -148,7 +185,40 @@ jobs:
           python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==2.22.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-musllinux-${{matrix.arch}}
+          path: ./wheelhouse/*.whl
+
+  build_wheels_musllinux_arm:
+    name: Build wheels on musllinux_1_2 for ${{ matrix.arch }}
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        arch: [aarch64]
+        
+    env:
+      CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2
+      CIBW_BUILD: cp3*-musllinux*
+      CIBW_ARCHS: ${{matrix.arch}}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Update to musllinux_1_2 and using ubuntu-24.04-arm runner for aarch64